### PR TITLE
Include runtime warnings

### DIFF
--- a/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
@@ -15,7 +15,7 @@
 const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
 const util = require('util');
 const {auditNotApplicable} = require('../utils/builder');
-const {AUDITS, NOT_APPLICABLE} = require('../messages/messages.js');
+const {AUDITS, NOT_APPLICABLE, WARNINGS} = require('../messages/messages.js');
 const {Audit} = require('lighthouse');
 const {getAdStartTime, getPageResponseTime, getPageStartTime} = require('../utils/network-timing');
 
@@ -67,6 +67,7 @@ class AdRequestFromPageStart extends Audit {
       return auditNotApplicable(NOT_APPLICABLE.NO_RECORDS);
     }
     if (adStartTime < 0) {
+      context.LighthouseRunWarnings.push(WARNINGS.NO_ADS);
       return auditNotApplicable(NOT_APPLICABLE.NO_ADS);
     }
 

--- a/lighthouse-plugin-publisher-ads/audits/first-ad-paint.js
+++ b/lighthouse-plugin-publisher-ads/audits/first-ad-paint.js
@@ -14,7 +14,7 @@
 
 const util = require('util');
 const {auditNotApplicable} = require('../utils/builder');
-const {AUDITS, NOT_APPLICABLE} = require('../messages/messages.js');
+const {AUDITS, NOT_APPLICABLE, WARNINGS} = require('../messages/messages.js');
 const {Audit} = require('lighthouse');
 const {isGptIframe} = require('../utils/resource-classification');
 
@@ -76,6 +76,7 @@ class FirstAdPaint extends Audit {
     const {traceEvents} = artifacts.traces[Audit.DEFAULT_PASS];
     const slots = artifacts.IFrameElements.filter(isGptIframe);
     if (slots.length == 0) {
+      context.LighthouseRunWarnings.push(WARNINGS.NO_AD_RENDERED);
       return auditNotApplicable(NOT_APPLICABLE.NO_AD_RENDERED);
     }
 

--- a/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
+++ b/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
@@ -15,7 +15,7 @@
 const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
 const util = require('util');
 const {auditNotApplicable} = require('../utils/builder');
-const {AUDITS, NOT_APPLICABLE} = require('../messages/messages.js');
+const {AUDITS, NOT_APPLICABLE, WARNINGS} = require('../messages/messages.js');
 const {Audit} = require('lighthouse');
 const {getPageResponseTime, getPageStartTime, getTagEndTime} = require('../utils/network-timing');
 
@@ -64,6 +64,7 @@ class TagLoadTime extends Audit {
       return auditNotApplicable(NOT_APPLICABLE.NO_RECORDS);
     }
     if (tagEndTime < 0) {
+      context.LighthouseRunWarnings.push(WARNINGS.NO_TAG);
       return auditNotApplicable(NOT_APPLICABLE.NO_TAG);
     }
 

--- a/lighthouse-plugin-publisher-ads/messages/en-US.json
+++ b/lighthouse-plugin-publisher-ads/messages/en-US.json
@@ -203,7 +203,7 @@
   },
   "WARNINGS": {
     "NO_ADS": "No ads were requested when fetching this page.",
-    "NO_AD_RENDERED": "No ads were rendered when fetching this page.",
+    "NO_AD_RENDERED": "No ads were painted when rendering this page.",
     "NO_TAG": "The GPT tag was not requested."
   },
   "GROUPS": {

--- a/lighthouse-plugin-publisher-ads/messages/en-US.json
+++ b/lighthouse-plugin-publisher-ads/messages/en-US.json
@@ -201,6 +201,11 @@
     "AREA_LARGER_THAN_VIEWPORT": "Calculated ad area is larger than viewport",
     "VIEWPORT_AREA_ZERO": "Viewport area is zero"
   },
+  "WARNINGS": {
+    "NO_ADS": "No ads were requested when fetching this page.",
+    "NO_AD_RENDERED": "No ads were rendered when fetching this page.",
+    "NO_TAG": "The GPT tag was not requested."
+  },
   "GROUPS": {
     "METRICS": "Metrics",
     "ADS_PERFORMANCE": "Ad Speed",

--- a/lighthouse-plugin-publisher-ads/test/audits/tag-load-time_test.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/tag-load-time_test.js
@@ -56,7 +56,10 @@ describe('TagLoadTime', async () => {
       of testCases) {
       it(`${desc} with a load time of ${expectedLoadTime}`, async () => {
         sandbox.stub(NetworkRecords, 'request').returns(networkRecords);
-        const results = await TagLoadTime.audit({devtoolsLogs: {}}, {});
+        const results = await TagLoadTime.audit(
+          {devtoolsLogs: {}},
+          {LighthouseRunWarnings: []}
+        );
         if (!expectedNotAppl) {
           expect(results).to.have.property('numericValue', expectedLoadTime);
         } else {


### PR DESCRIPTION
Include runtime warnings when:
  - No ad is requested
  - No ad is rendered
  - No GPT tag is loaded