### PR TITLE
Fix script-injected-tags regression

### DIFF
--- a/lighthouse-plugin-publisher-ads/audits/script-injected-tags.js
+++ b/lighthouse-plugin-publisher-ads/audits/script-injected-tags.js
@@ -92,13 +92,12 @@ class ScriptInjectedTags extends Audit {
       {trace, devtoolsLog}, context);
 
     const closure = getTransitiveClosure(mainDocumentNode, isGptAdRequest);
-    console.log(closure.requests.length);
     if (!closure.requests.length) {
       return auditNotApplicable(NOT_APPLICABLE.NO_AD_RELATED_REQ);
     }
     const injectedBlockingRequests = closure.requests
-        .filter((r) => r.resourceType == 'Script')
-        .filter((r) => r.initiator.type == 'script')
+        .filter((r) =>
+          r.resourceType == 'Script' && r.initiator.type == 'script')
         .filter((r) =>
           r.initiatorRequest && r.initiatorRequest.url == r.documentURL);
 

--- a/lighthouse-plugin-publisher-ads/audits/script-injected-tags.js
+++ b/lighthouse-plugin-publisher-ads/audits/script-injected-tags.js
@@ -92,8 +92,9 @@ class ScriptInjectedTags extends Audit {
       {trace, devtoolsLog}, context);
 
     const closure = getTransitiveClosure(mainDocumentNode, isGptAdRequest);
+    console.log(closure.requests.length);
     if (!closure.requests.length) {
-      return auditNotApplicable(NOT_APPLICABLE.NO_RECORDS);
+      return auditNotApplicable(NOT_APPLICABLE.NO_AD_RELATED_REQ);
     }
     const injectedBlockingRequests = closure.requests
         .filter((r) => r.resourceType == 'Script')


### PR DESCRIPTION
Regression was introduced in #70 where `NetworkNode` started being used in place of `NetworkRequest` in the `utils/graph.js`.

Follow-up action items are:

- Identify how to prevent this sort of issue in the compiler in general. My understanding is that this slipped through because `any` isn't robustly checked against.
- Develop more robust tests (perhaps via #21)