### PR TITLE
Fix missing resources in the critical path audit

### DIFF
--- a/lighthouse-plugin-publisher-ads/audits/ad-request-critical-path.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-critical-path.js
@@ -215,7 +215,7 @@ class AdRequestCriticalPath extends Audit {
 
     /** @type {Map<NetworkRequest, NodeTiming>} */
     const timingsByRecord =
-        await getTimingsByRecord(trace, devtoolsLog, criticalRequests, context);
+        await getTimingsByRecord(trace, devtoolsLog, context);
     const REQUEST_TYPES = ['Script', 'XHR', 'Fetch', 'EventStream', 'Document'];
     const blockingRequests = Array.from(criticalRequests)
         .filter((r) => REQUEST_TYPES.includes(r.resourceType))

--- a/lighthouse-plugin-publisher-ads/audits/script-injected-tags.js
+++ b/lighthouse-plugin-publisher-ads/audits/script-injected-tags.js
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
 const PageDependencyGraph = require('lighthouse/lighthouse-core/computed/page-dependency-graph');
 const {auditNotApplicable} = require('../utils/builder');
 const {AUDITS, NOT_APPLICABLE} = require('../messages/messages');
@@ -91,7 +90,6 @@ class ScriptInjectedTags extends Audit {
   static async audit(artifacts, context) {
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
     const trace = artifacts.traces[Audit.DEFAULT_PASS];
-    const networkRecords = await NetworkRecords.request(devtoolsLog, context);
     // @ts-ignore
     const mainDocumentNode = await PageDependencyGraph.request(
       {trace, devtoolsLog}, context);
@@ -108,7 +106,7 @@ class ScriptInjectedTags extends Audit {
 
     /** @type {Map<NetworkRequest, NodeTiming>} */
     const timings = await getTimingsByRecord(
-      trace, devtoolsLog, new Set(networkRecords), context);
+      trace, devtoolsLog, context);
     const tableView = injectedBlockingRequests.map((req) =>
       Object.assign({}, timings.get(req), {
         request: req.url,

--- a/lighthouse-plugin-publisher-ads/audits/serial-header-bidding.js
+++ b/lighthouse-plugin-publisher-ads/audits/serial-header-bidding.js
@@ -163,7 +163,7 @@ class SerialHeaderBidding extends Audit {
 
     /** @type {Map<NetworkRequest, NodeTiming>} */
     const timingsByRecord = await getTimingsByRecord(
-      trace, devtoolsLog, new Set(networkRecords), context);
+      trace, devtoolsLog, context);
 
     // Construct shallow copies of records. If no records are found, return [].
     const adsRecords = constructRecords(

--- a/lighthouse-plugin-publisher-ads/utils/network-timing.js
+++ b/lighthouse-plugin-publisher-ads/utils/network-timing.js
@@ -19,6 +19,7 @@ const CpuNode = require('lighthouse/lighthouse-core/lib/dependency-graph/cpu-nod
 const LoadSimulator = require('lighthouse/lighthouse-core/computed/load-simulator');
 // eslint-disable-next-line no-unused-vars
 const NetworkNode = require('lighthouse/lighthouse-core/lib/dependency-graph/network-node.js');
+const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
 const PageDependencyGraph = require('lighthouse/lighthouse-core/computed/page-dependency-graph');
 const {isGptAdRequest, isImplTag} = require('./resource-classification');
 const {URL} = require('url');
@@ -76,14 +77,13 @@ function getPageResponseTime(networkRecords, defaultValue = -1) {
 /**
  * @param {LH.Trace} trace
  * @param {LH.DevtoolsLog} devtoolsLog
- * @param {Set<NetworkRequest>} networkRecords
  * @param {LH.Audit.Context} context
  * @return {Promise<Map<NetworkRequest, NodeTiming>>}
  */
-async function getTimingsByRecord(trace, devtoolsLog, networkRecords, context) {
+async function getTimingsByRecord(trace, devtoolsLog, context) {
   /** @type {Map<NetworkRequest, NodeTiming>} */
   const timingsByRecord = new Map();
-
+  const networkRecords = await NetworkRecords.request(devtoolsLog, context);
   if (context.settings.throttlingMethod == 'simulate') {
     /** @type {NetworkNode} */
     const documentNode =
@@ -98,7 +98,7 @@ async function getTimingsByRecord(trace, devtoolsLog, networkRecords, context) {
       timingsByRecord.set(record, timing);
     }
   } else {
-    const pageStartTime = getPageStartTime(Array.from(networkRecords));
+    const pageStartTime = getPageStartTime(networkRecords);
     for (const record of networkRecords) {
       timingsByRecord.set(record, {
         startTime: (record.startTime - pageStartTime) * 1000,


### PR DESCRIPTION
The page time origin would be miscalculated when looking up timings in `getTimingsByRecord` because the array of networks records passed to `getPageRequestTime` was not sorted. (So the wrong time would be returned because it returns the time of the first successful request.) To add to the problem, the array only included "critical requests", which I don't think contains the main document request. (So the wrong time origin would be returned even if the array was sorted.)

I fix the issue by re-computing network records based on `devtoolsLog`. (Note that the computation is cached so there is no serious impact on performance.) As a follow up I would like to refactor code to avoid implicit assumptions.

Tested by running reports. As a follow up lets look at setting up tests based on artifacts.