### PR TITLE
Refactor serial bids audit to cover a missing case

### DIFF
--- a/lighthouse-plugin-publisher-ads/audits/serial-header-bidding.js
+++ b/lighthouse-plugin-publisher-ads/audits/serial-header-bidding.js
@@ -182,9 +182,11 @@ class SerialHeaderBidding extends Audit {
     const headerBiddingRecords = constructRecords(
       recordsByType.get(RequestType.BID) || [], RequestType.BID,
       timingsByRecord);
-    /** @type {NetworkDetails.RequestRecord[]} */ let serialBids = [];
+    /** @type {NetworkDetails.RequestRecord[]} */
+    let serialBids = [];
     let previousBid;
 
+    // Iterate forward in order of start time.
     for (const record of headerBiddingRecords) {
       record.bidder = getHeaderBidder(record.url);
       record.url = clearQueryString(record.url);
@@ -193,7 +195,9 @@ class SerialHeaderBidding extends Audit {
         serialBids.push(previousBid);
         serialBids.push(record);
       }
+      // Point previousBid to the most the one with the earliest end time.
       if (!previousBid || record.endTime < previousBid.endTime ||
+          // But move on if this bid does not overlap with the previous one.
           record.startTime >= previousBid.endTime) {
         previousBid = record;
       }

--- a/lighthouse-plugin-publisher-ads/audits/serial-header-bidding.js
+++ b/lighthouse-plugin-publisher-ads/audits/serial-header-bidding.js
@@ -40,7 +40,6 @@ const MIN_BID_DURATION = .05;
  * @typedef {Object} BidRequest
  * @property {string | boolean} bidder
  * @property {string} url
- * @property {string} initiator
  * @property {number} startTime
  * @property {number} endTime
  * @property {number} duration

--- a/lighthouse-plugin-publisher-ads/messages/en-US.json
+++ b/lighthouse-plugin-publisher-ads/messages/en-US.json
@@ -20,7 +20,6 @@
       "failureDisplayValue": "Up to {opportunity, number, seconds} s tag load time improvement",
       "headings": {
         "url": "Resource",
-        "initiator": "Initiatior",
         "startTime": "Start Time",
         "endTime": "End Time",
         "duration": "Duration"
@@ -153,7 +152,6 @@
       "headings": {
         "bidder": "Bidder",
         "url": "URL",
-        "initiator": "Initiatior",
         "startTime": "Start Time",
         "endTime": "End Time",
         "duration": "Duration"

--- a/lighthouse-plugin-publisher-ads/messages/en-US.json
+++ b/lighthouse-plugin-publisher-ads/messages/en-US.json
@@ -20,6 +20,7 @@
       "failureDisplayValue": "Up to {opportunity, number, seconds} s tag load time improvement",
       "headings": {
         "url": "Resource",
+        "initiator": "Initiatior",
         "startTime": "Start Time",
         "endTime": "End Time",
         "duration": "Duration"
@@ -152,6 +153,7 @@
       "headings": {
         "bidder": "Bidder",
         "url": "URL",
+        "initiator": "Initiatior",
         "startTime": "Start Time",
         "endTime": "End Time",
         "duration": "Duration"

--- a/lighthouse-plugin-publisher-ads/test/audits/serial-header-bidding_test.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/serial-header-bidding_test.js
@@ -83,6 +83,15 @@ describe('SerialHeaderBidding', async () => {
         expectedScore: 0,
       },
       {
+        desc: 'should fail for records that are mutually serial',
+        networkRecords: [
+          {url: 'https://aax.amazon-adsystem.com/e/dtb/bid', startTime: 11, endTime: 16},
+          {url: 'http://contextual.media.net/bidexchange.js', startTime: 12, endTime: 13},
+          {url: 'http://as.casalemedia.com/cygnus', startTime: 14, endTime: 15},
+        ],
+        expectedScore: 0,
+      },
+      {
         desc: 'should ignore resources with 0 resource size',
         networkRecords: [
           {url: 'https://aax.amazon-adsystem.com/e/dtb/bid', startTime: 5, endTime: 10, resourceSize: 100},

--- a/lighthouse-plugin-publisher-ads/test/audits/serial-header-bidding_test.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/serial-header-bidding_test.js
@@ -389,8 +389,7 @@ describe('SerialHeaderBidding', async () => {
       },
     ];
 
-    for (const {desc, networkRecords, expectedAdsRecords,
-      expectedHeaderBiddingRecords, expectedNotAppl} of testCases) {
+    for (const {desc, networkRecords, expectedNotAppl} of testCases) {
       it(`should have ${desc}`, async () => {
         sandbox.stub(NetworkRecords, 'request').returns(networkRecords);
         const results = await SerialHeaderBidding.audit(
@@ -398,10 +397,7 @@ describe('SerialHeaderBidding', async () => {
         if (expectedNotAppl) {
           expect(results).to.have.property('notApplicable', true);
         } else {
-          expect(results).with.property('extendedInfo')
-              .property('adsRecords').eql(expectedAdsRecords);
-          expect(results).with.property('extendedInfo')
-              .property('headerBiddingRecords').eql(expectedHeaderBiddingRecords);
+          expect(results).to.not.have.property('notApplicable');
         }
       });
     }

--- a/lighthouse-plugin-publisher-ads/typings/audits.d.ts
+++ b/lighthouse-plugin-publisher-ads/typings/audits.d.ts
@@ -30,6 +30,7 @@ declare global {
       endTime: number;
       duration: number,
       url: string;
+      bidder?: string;
       type: string;
       abbreviatedUrl?: string;
     }

--- a/lighthouse-plugin-publisher-ads/utils/resource-classification.js
+++ b/lighthouse-plugin-publisher-ads/utils/resource-classification.js
@@ -93,7 +93,7 @@ function hasImpressionPath(url) {
 /**
  * Returns header bidder or false if not a bid.
  * @param {string} url
- * @return {string | boolean}
+ * @return {string|undefined}
  */
 function getHeaderBidder(url) {
   for (const def of bidderPatterns) {
@@ -103,7 +103,7 @@ function getHeaderBidder(url) {
       }
     }
   }
-  return false;
+  return undefined;
 }
 
 /**

--- a/lighthouse-plugin-publisher-ads/utils/resource-classification.js
+++ b/lighthouse-plugin-publisher-ads/utils/resource-classification.js
@@ -91,7 +91,7 @@ function hasImpressionPath(url) {
 }
 
 /**
- * Returns header bidder or false if not a bid.
+ * Returns header bidder or undefined if not a bid.
  * @param {string} url
  * @return {string|undefined}
  */


### PR DESCRIPTION
Fixes a case where some some serial bids would not be caught. Suppose the following three bids:

  A: [100, 600]
  B: [200, 300]
  C: [400, 500]

B and C are mutually serial but the current algorithm would ignore them because they overlap with A. This PR fixes that case