### PR TITLE
Remove endTime column from tables for brevity (from most audits)

### DIFF
--- a/lighthouse-plugin-publisher-ads/audits/ad-blocking-tasks.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-blocking-tasks.js
@@ -49,7 +49,6 @@ const LONG_TASK_DUR_MS = 100;
 const HEADINGS = [
   {key: 'script', itemType: 'url', text: headings.script},
   {key: 'startTime', itemType: 'ms', text: headings.startTime, granularity: 1},
-  {key: 'endTime', itemType: 'ms', text: headings.endTime, granularity: 1},
   {key: 'duration', itemType: 'ms', text: headings.duration, granularity: 1},
 ];
 

--- a/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
@@ -49,12 +49,6 @@ const HEADINGS = [
     granularity: 1,
   },
   {
-    key: 'endTime',
-    itemType: 'ms',
-    text: headings.endTime,
-    granularity: 1,
-  },
-  {
     key: 'duration',
     itemType: 'ms',
     text: headings.duration,

--- a/lighthouse-plugin-publisher-ads/audits/ad-request-critical-path.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-critical-path.js
@@ -70,12 +70,6 @@ const HEADINGS = [
     text: headings.endTime,
     granularity: 1,
   },
-  {
-    key: 'duration',
-    itemType: 'ms',
-    text: headings.duration,
-    granularity: 1,
-  },
 ];
 
 /**

--- a/lighthouse-plugin-publisher-ads/audits/idle-network-times.js
+++ b/lighthouse-plugin-publisher-ads/audits/idle-network-times.js
@@ -75,12 +75,6 @@ const HEADINGS = [
     granularity: 1,
   },
   {
-    key: 'endTime',
-    itemType: 'ms',
-    text: headings.endTime,
-    granularity: 1,
-  },
-  {
     key: 'duration',
     itemType: 'ms',
     text: headings.duration,

--- a/lighthouse-plugin-publisher-ads/audits/serial-header-bidding.js
+++ b/lighthouse-plugin-publisher-ads/audits/serial-header-bidding.js
@@ -53,7 +53,6 @@ const HEADINGS = [
   {key: 'bidder', itemType: 'text', text: headings.bidder},
   {key: 'url', itemType: 'url', text: headings.url},
   {key: 'startTime', itemType: 'ms', text: headings.startTime},
-  {key: 'endTime', itemType: 'ms', text: headings.endTime},
   {key: 'duration', itemType: 'ms', text: headings.duration},
 ];
 

--- a/lighthouse-plugin-publisher-ads/messages/en-US.json
+++ b/lighthouse-plugin-publisher-ads/messages/en-US.json
@@ -9,7 +9,6 @@
       "headings": {
         "script": "Attributable URL",
         "startTime": "Start",
-        "endTime": "End",
         "duration": "Duration"
       }
     },
@@ -20,8 +19,7 @@
       "failureDisplayValue": "Up to {opportunity, number, seconds} s tag load time improvement",
       "headings": {
         "url": "Resource",
-        "startTime": "Start Time",
-        "endTime": "End Time",
+        "startTime": "Start",
         "duration": "Duration"
       }
     },
@@ -33,8 +31,8 @@
       "headings": {
         "url": "Request",
         "type": "Type",
-        "startTime": "Start Time",
-        "endTime": "End Time",
+        "startTime": "Start",
+        "endTime": "End",
         "duration": "Duration"
       }
     },
@@ -108,8 +106,7 @@
       "headings": {
         "cause": "Suspected Cause",
         "url": "Attributable URL",
-        "startTime": "Start Time",
-        "endTime": "End Time",
+        "startTime": "Start",
         "duration": "Duration"
       },
       "causes": {
@@ -140,7 +137,7 @@
       "displayValue": "{numTags} script-injected {numTags, plural, =1 {resources} other {resources}}",
       "headings": {
         "request": "Request",
-        "startTime": "Start Time",
+        "startTime": "Start",
         "duration": "Duration",
         "lineNumber": "Source Line Number"
       }
@@ -152,8 +149,7 @@
       "headings": {
         "bidder": "Bidder",
         "url": "URL",
-        "startTime": "Start Time",
-        "endTime": "End Time",
+        "startTime": "Start",
         "duration": "Duration"
       }
     },


### PR DESCRIPTION
Tables that display three columns of numbers are hard to grok so this PR updates tables to show only three columns. For most audits, start time and duration are the most important figures (think long tasks, idle times). However, end time makes more sense than duration for the critical path audit to make initiator comparisons easier. (That is, if a.startTime > b.endTime, then there is a good chance than a depends on b. But it's hard to do the mental math with enough precision of using startTime + duration)