### PR TITLE
Disable simulated throttling by default.

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,11 @@ async function main() {
     process.argv.push(`--config-path=${configPath}`);
   }
 
+  if (!yargs.argv.throttlingMethod) {
+    // Disable simulation.
+    process.argv.push('--throttling-method=provided');
+  }
+
   if (!yargs.argv.chromeFlags) {
     // TODO: merge if extra flags are specified
     process.argv.push('--chrome-flags=--headless');


### PR DESCRIPTION
This is a temporary change until simulated results can be verified as accurate.