### PR TITLE
Update blocking requests audit to check all sync resources

### DIFF
--- a/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
@@ -123,6 +123,7 @@ class AdRenderBlockingResources extends Audit {
         // Don't fail on sync resources loaded after the tag. This includes sync
         // resources loaded inside of iframes.
         .filter((r) => r.endTime < tag.startTime)
+        .filter((r) => r != tag.initiatorRequest)
         // Sanity check to filter out duplicate requests which were async. If
         // type != parser then the resource was dynamically added and is
         // therefore async (non-blocking).

--- a/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
@@ -145,9 +145,10 @@ class AdRenderBlockingResources extends Audit {
         UIStrings.failureDisplayValue, {timeInMs: opportunity});
     }
 
+    const failed = tableView.length > 0;
     return {
+      score: failed ? 0 : 1,
       numericValue: tableView.length,
-      score: tableView.length ? 0 : 1,
       displayValue,
       details: AdRenderBlockingResources.makeTableDetails(HEADINGS, tableView),
     };

--- a/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
@@ -120,7 +120,12 @@ class AdRenderBlockingResources extends Audit {
     }
 
     const blockingNetworkRecords = networkRecords
+        // Don't fail on sync resources loaded after the tag. This includes sync
+        // resources loaded inside of iframes.
         .filter((r) => r.endTime < tag.startTime)
+        // Sanity check to filter out duplicate requests which were async. If
+        // type != parser then the resource was dynamically added and is
+        // therefore async (non-blocking).
         .filter((r) => r.initiator.type = 'parser')
         .filter((r) => blockingElementUrls.has(r.url));
 

--- a/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
@@ -130,7 +130,9 @@ class AdRenderBlockingResources extends Audit {
     tableView.sort((a, b) => a.endTime - b.endTime);
 
     // @ts-ignore
-    const opportunity = Math.max(...tableView.map((r) => r.duration));
+    const opportunity =
+        Math.max(...tableView.map((r) => r.endTime)) -
+        Math.min(...tableView.map((r) => r.endTime));
     let displayValue = '';
     if (tableView.length > 0 && opportunity > 0) {
       displayValue = str_(

--- a/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
@@ -136,9 +136,8 @@ class AdRenderBlockingResources extends Audit {
     tableView.sort((a, b) => a.endTime - b.endTime);
 
     // @ts-ignore
-    const opportunity =
-        Math.max(...tableView.map((r) => r.endTime)) -
-        Math.min(...tableView.map((r) => r.endTime));
+    const endTimes = tableView.map((r) => r.endTime);
+    const opportunity = Math.max(...endTimes) - Math.min(...endTimes);
     let displayValue = '';
     if (tableView.length > 0 && opportunity > 0) {
       displayValue = str_(

--- a/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
@@ -15,10 +15,9 @@
 const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
 const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
 // @ts-ignore
-const RenderBlockingResources = require('lighthouse/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
-const {getPageStartTime} = require('../utils/network-timing');
+const {getTimingsByRecord} = require('../utils/network-timing');
 const {isAdTag} = require('../utils/resource-classification');
 const {URL} = require('url');
 
@@ -36,6 +35,9 @@ const UIStrings = {
   columnStartTime: 'Start',
   columnDuration: 'Duration',
 };
+
+/** @typedef {LH.Artifacts.NetworkRequest} NetworkRequest */
+/** @typedef {LH.Gatherer.Simulation.NodeTiming} NodeTiming */
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 
@@ -64,7 +66,7 @@ const HEADINGS = [
 ];
 
 /** Audits for render blocking resources */
-class AdRenderBlockingResources extends RenderBlockingResources {
+class AdRenderBlockingResources extends Audit {
   /**
    * @return {LH.Audit.Meta}
    * @override
@@ -76,7 +78,8 @@ class AdRenderBlockingResources extends RenderBlockingResources {
       failureTitle: str_(UIStrings.failureTitle),
       scoreDisplayMode: 'binary',
       description: str_(UIStrings.description),
-      requiredArtifacts: RenderBlockingResources.meta.requiredArtifacts,
+      requiredArtifacts:
+          ['LinkElements', 'ScriptElements', 'devtoolsLogs', 'traces'],
     };
   }
 
@@ -87,40 +90,56 @@ class AdRenderBlockingResources extends RenderBlockingResources {
    */
   static async audit(artifacts, context) {
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
+    const trace = artifacts.traces[Audit.DEFAULT_PASS];
     const networkRecords = await NetworkRecords.request(devtoolsLog, context);
-    const hasTag = !!networkRecords.find((req) => isAdTag(new URL(req.url)));
-    if (!hasTag) {
+    const tag = networkRecords.find((req) => isAdTag(new URL(req.url)));
+    if (!tag) {
       return auditNotApplicable.NoTag;
     }
 
-    const {results} = await RenderBlockingResources.computeResults(
-      artifacts, context);
+    /** @type {Map<NetworkRequest, NodeTiming>} */
+    const timingsByRecord =
+      await getTimingsByRecord(trace, devtoolsLog, context);
 
-    const pageStartTime = getPageStartTime(networkRecords);
-    const tableView = results
-        // @ts-ignore
-        .map((r) => networkRecords.find((n) => n.url === r.url))
-        .filter(Boolean)
-        // @ts-ignore
-        .map((record) => ({
-          url: record.url,
-          // TODO: line number
-          startTime: (record.startTime - pageStartTime) * 1000,
-          endTime: (record.endTime - pageStartTime) * 1000,
-          duration: (record.endTime - record.startTime) * 1000,
-        }));
+    // NOTE(warrengm): Ideally we would key be requestId here but LinkElements
+    // don't have request IDs.
+    /** @type {Set<string>} */
+    const blockingElementUrls = new Set();
+    for (const link of artifacts.LinkElements) {
+      // TODO(warrengm): Check for media queries? Or is the network filter below
+      // sufficient?
+      if (link.href && link.rel == 'stylesheet') {
+        // NOTE that href here is normalized to the URL that went over the wire.
+        blockingElementUrls.add(link.href);
+      }
+    }
+    for (const script of artifacts.ScriptElements) {
+      if (script.src && !script.defer && !script.async) {
+        blockingElementUrls.add(script.src);
+      }
+    }
+
+    const blockingNetworkRecords = networkRecords
+        .filter((r) => r.endTime < tag.startTime)
+        .filter((r) => r.initiator.type = 'parser')
+        .filter((r) => blockingElementUrls.has(r.url));
+
+    const tableView = blockingNetworkRecords
+        .map((r) => Object.assign({url: r.url}, timingsByRecord.get(r)));
+
+    tableView.sort((a, b) => a.endTime - b.endTime);
 
     // @ts-ignore
     const opportunity = Math.max(...tableView.map((r) => r.duration));
     let displayValue = '';
-    if (results.length > 0 && opportunity > 0) {
+    if (tableView.length > 0 && opportunity > 0) {
       displayValue = str_(
         UIStrings.failureDisplayValue, {timeInMs: opportunity});
     }
 
     return {
-      numericValue: results.length,
-      score: results.length ? 0 : 1,
+      numericValue: tableView.length,
+      score: tableView.length ? 0 : 1,
       displayValue,
       details: AdRenderBlockingResources.makeTableDetails(HEADINGS, tableView),
     };

--- a/lighthouse-plugin-publisher-ads/audits/blocking-load-events.js
+++ b/lighthouse-plugin-publisher-ads/audits/blocking-load-events.js
@@ -160,7 +160,7 @@ class BlockingLoadEvents extends Audit {
       title: str_(UIStrings.title),
       failureTitle: str_(UIStrings.failureTitle),
       description: str_(UIStrings.description),
-      requiredArtifacts: ['devtoolsLogs', 'traces', 'TagsBlockingFirstPaint'],
+      requiredArtifacts: ['devtoolsLogs', 'traces'],
     };
   }
 

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/render-blocking-tags.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/render-blocking-tags.js
@@ -1,0 +1,54 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+/**
+ * Expected Lighthouse audit values for perf tests.
+ */
+module.exports = [
+  {
+    lhr: {
+      requestedUrl: 'http://localhost:8081/render-blocking-tags.html',
+      finalUrl: 'http://localhost:8081/render-blocking-tags.html',
+      audits: {
+        'ad-render-blocking-resources': {
+          scoreDisplayMode: 'binary',
+          score: 0,
+          numericValue: 2,
+          details: {
+            items: [
+              {url: 'http://localhost:8081/no-op-style.css'},
+              {url: 'http://localhost:8081/no-op-script.js'},
+            ],
+          },
+        },
+        'ad-request-critical-path': {
+          scoreDisplayMode: 'informative',
+          // It's important that the critical path does not include the render
+          // blocking resources.
+          numericValue: 4,
+          details: {
+            items: [
+              {url: 'http://localhost:8081/slowly-inject-gpt.js'},
+              {url: 'http://securepubads.g.doubleclick.net/tag/js/gpt.js'},
+              {url: 'https://securepubads.g.doubleclick.net/tag/js/gpt.js'},
+              // Use a Regexp to ignore the version of pubads_impl.
+              {url: /.*securepubads.g.doubleclick.net.*pubads_impl.*/},
+            ],
+          },
+        },
+      },
+    },
+  },
+];

--- a/lighthouse-plugin-publisher-ads/test/smoke/fixtures/no-op-script.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/fixtures/no-op-script.js
@@ -1,0 +1,1 @@
+// Does nothing.

--- a/lighthouse-plugin-publisher-ads/test/smoke/fixtures/no-op-style.css
+++ b/lighthouse-plugin-publisher-ads/test/smoke/fixtures/no-op-style.css
@@ -1,0 +1,1 @@
+/* does nothing */

--- a/lighthouse-plugin-publisher-ads/test/smoke/fixtures/render-blocking-tags.html
+++ b/lighthouse-plugin-publisher-ads/test/smoke/fixtures/render-blocking-tags.html
@@ -16,7 +16,7 @@
 -->
 <html>
   <head>
-    <title>Script Injected Tags</title>
+    <title>Render Blocking Tags</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <script>googletag = window.googletag || {cmd: []};</script>

--- a/lighthouse-plugin-publisher-ads/test/smoke/fixtures/render-blocking-tags.html
+++ b/lighthouse-plugin-publisher-ads/test/smoke/fixtures/render-blocking-tags.html
@@ -20,8 +20,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <script>googletag = window.googletag || {cmd: []};</script>
-    <script async src="./slowly-inject-gpt.js"></script>
+    <link rel=stylesheet href="./no-op-style.css">
   <body>
+      <script src="./no-op-script.js"></script>
+      <!-- Note: we dynamically insert gpt.js here to hide it from the preload
+           scanner. Also, we want to verify that slow-inject-gpt.js doesn't
+           count as a gpt.js render blocking script. -->
+      <script src="./slowly-inject-gpt.js"></script>
       <script>
           googletag.cmd.push(function() {
             googletag.defineSlot('/6355419/Travel', [728, 90], `div0`)

--- a/lighthouse-plugin-publisher-ads/test/smoke/fixtures/script-injected.html
+++ b/lighthouse-plugin-publisher-ads/test/smoke/fixtures/script-injected.html
@@ -20,7 +20,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <script>googletag = window.googletag || {cmd: []};</script>
-    <script async src="./slowly-inject-gpt.js"></script>
+    <script src="./slowly-inject-gpt.js"></script>
   <body>
       <script>
           googletag.cmd.push(function() {

--- a/lighthouse-plugin-publisher-ads/test/smoke/smoke-test-dfns.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/smoke-test-dfns.js
@@ -28,6 +28,12 @@ const smokeTests = [
     batch: 'pub-ads',
   },
   {
+    id: 'render-blocking-tasks',
+    expectations: require('./expectations/render-blocking-tags.js'),
+    config: require('./config.js'),
+    batch: 'pub-ads',
+  },
+  {
     id: 'script-injected',
     expectations: require('./expectations/script-injected.js'),
     config: require('./config.js'),


### PR DESCRIPTION
The `ad-render-blocking-resources` audit currently only checks for resources blocking first paint but we care about any sync resource that blocks ad loading.

This PR also add support for simulation as part of the refactoring.