### PR TITLE
Update render-blocking resources audit display

### DIFF
--- a/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
@@ -22,9 +22,9 @@ const {isAdTag} = require('../utils/resource-classification');
 const {URL} = require('url');
 
 const UIStrings = {
-  title: 'Minimal render-blocking resources found',
-  failureTitle: 'Avoid render-blocking resources',
-  description: 'Render-blocking resources slow down tag load times. Consider ' +
+  title: 'Minimal synchronous resources found',
+  failureTitle: 'Avoid synchronous resources',
+  description: 'Synchronous resources slow down tag load times. Consider ' +
   'loading critical JS/CSS inline or loading scripts asynchronously or ' +
   'loading the tag earlier in the head. [Learn more](' +
   'https://developers.google.com/web/tools/lighthouse/audits/blocking-resources' +
@@ -133,11 +133,11 @@ class AdRenderBlockingResources extends Audit {
     const tableView = blockingNetworkRecords
         .map((r) => Object.assign({url: r.url}, timingsByRecord.get(r)));
 
-    tableView.sort((a, b) => a.endTime - b.endTime);
+    tableView.sort((a, b) => a.startTime - b.startTime);
 
-    // @ts-ignore
-    const endTimes = tableView.map((r) => r.endTime);
-    const opportunity = Math.max(...endTimes) - Math.min(...endTimes);
+    const opportunity =
+      Math.max(...tableView.map((r) => r.endTime)) -
+      Math.min(...tableView.map((r) => r.startTime));
     let displayValue = '';
     if (tableView.length > 0 && opportunity > 0) {
       displayValue = str_(


### PR DESCRIPTION
A few changes:
- "Render-blocking" -> "synchronous"
- Sort results by start time rather than end time since the display table only shows start time
- Count the opportunity from the first start time rather than first end time so that it's accurate for pages with only one sync resource 
