### PR TITLE
Update checked tags in `duplicate-tags` audit.

### DIFF
--- a/lighthouse-plugin-publisher-ads/audits/duplicate-tags.js
+++ b/lighthouse-plugin-publisher-ads/audits/duplicate-tags.js
@@ -38,8 +38,7 @@ const tags = [
   'googletagservices.com/tag/js/gpt.js',
   'securepubads.g.doubleclick.net/tag/js/gpt.js',
   'pagead2.googlesyndication.com/pagead/js/adsbygoogle.js',
-  'imasdk.googleapis.com/js/sdkloader/ima3.js',
-  'google-analytics.com/analytics.js',
+  'pagead2.googlesyndication.com/pagead/js/show_ads.js',
 ];
 
 /**


### PR DESCRIPTION
Removed non-ad-related tags, and included additional AdSense tag.