### PR TITLE
Remove special-cased score rounding from numeric audits.

### DIFF
--- a/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
@@ -71,16 +71,9 @@ class AdRequestFromPageStart extends Audit {
       return auditNotApplicable.NoAds;
     }
 
-    let normalScore = Audit.computeLogNormalScore(timing, PODR, MEDIAN);
-
-    // Results that have green text should be under passing category.
-    if (normalScore >= .9) {
-      normalScore = 1;
-    }
-
     return {
       numericValue: timing * 1e-3,
-      score: normalScore,
+      score: Audit.computeLogNormalScore(timing, PODR, MEDIAN),
       displayValue: str_(UIStrings.displayValue, {timeInMs: timing}),
     };
   }

--- a/lighthouse-plugin-publisher-ads/audits/ad-request-from-tag-load.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-from-tag-load.js
@@ -77,16 +77,9 @@ class AdRequestFromTagLoad extends Audit {
 
     const adReqTimeMs = (adStartTime - tagEndTime);
 
-    let normalScore = Audit.computeLogNormalScore(adReqTimeMs, PODR, MEDIAN);
-
-    // Results that have green text should be under passing category.
-    if (normalScore >= .9) {
-      normalScore = 1;
-    }
-
     return {
       numericValue: adReqTimeMs * 1e-3,
-      score: normalScore,
+      score: Audit.computeLogNormalScore(adReqTimeMs, PODR, MEDIAN),
       displayValue: str_(UIStrings.displayValue, {timeInMs: adReqTimeMs}),
     };
   }

--- a/lighthouse-plugin-publisher-ads/audits/bid-request-from-page-start.js
+++ b/lighthouse-plugin-publisher-ads/audits/bid-request-from-page-start.js
@@ -70,16 +70,9 @@ class BidRequestFromPageStart extends Audit {
       return auditNotApplicable.NoBids;
     }
 
-    let normalScore = Audit.computeLogNormalScore(timing, PODR, MEDIAN);
-
-    // Results that have green text should be under passing category.
-    if (normalScore >= .9) {
-      normalScore = 1;
-    }
-
     return {
       numericValue: timing * 1e-3,
-      score: normalScore,
+      score: Audit.computeLogNormalScore(timing, PODR, MEDIAN),
       displayValue: str_(UIStrings.displayValue, {timeInMs: timing}),
     };
   }

--- a/lighthouse-plugin-publisher-ads/audits/first-ad-render.js
+++ b/lighthouse-plugin-publisher-ads/audits/first-ad-render.js
@@ -74,13 +74,9 @@ class FirstAdRender extends Audit {
       return auditNotApplicable.NoAdRendered;
     }
 
-    let normalScore =
-        Audit.computeLogNormalScore(timing, PODR, MEDIAN);
-    if (normalScore >= 0.9) normalScore = 1;
-
     return {
       numericValue: timing * 1e-3,
-      score: normalScore,
+      score: Audit.computeLogNormalScore(timing, PODR, MEDIAN),
       displayValue:
         str_(UIStrings.displayValue, {timeInMs: timing}),
     };

--- a/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
+++ b/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
@@ -69,6 +69,8 @@ class TagLoadTime extends Audit {
       return auditNotApplicable.NoTag;
     }
 
+    // NOTE: score is relative to page response time to avoid counting time for
+    // first party rendering.
     return {
       numericValue: timing * 1e-3, // seconds
       score: Audit.computeLogNormalScore(timing, PODR, MEDIAN),

--- a/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
+++ b/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
@@ -69,18 +69,9 @@ class TagLoadTime extends Audit {
       return auditNotApplicable.NoTag;
     }
 
-    // NOTE: score is relative to page response time to avoid counting time for
-    // first party rendering.
-    let normalScore = Audit.computeLogNormalScore(timing, PODR, MEDIAN);
-
-    // Results that have green text should be under passing category.
-    if (normalScore >= .9) {
-      normalScore = 1;
-    }
-
     return {
       numericValue: timing * 1e-3, // seconds
-      score: normalScore,
+      score: Audit.computeLogNormalScore(timing, PODR, MEDIAN),
       displayValue: str_(UIStrings.displayValue, {timeInMs: timing}),
     };
   }


### PR DESCRIPTION
This was implemented to ensure that scores >= .9 did not appear as failing, but this issue has been fixed on the LH side.