### PR TITLE
Reweight audit scoring.

### DIFF
--- a/lighthouse-plugin-publisher-ads/plugin.js
+++ b/lighthouse-plugin-publisher-ads/plugin.js
@@ -57,8 +57,8 @@ module.exports = {
       // Measurements group.
       {id: 'tag-load-time', weight: 4, group: 'metrics'},
       {id: 'bid-request-from-page-start', weight: 4, group: 'metrics'},
-      {id: 'ad-request-from-page-start', weight: 4, group: 'metrics'},
-      {id: 'first-ad-render', weight: 8, group: 'metrics'},
+      {id: 'ad-request-from-page-start', weight: 20, group: 'metrics'},
+      {id: 'first-ad-render', weight: 10, group: 'metrics'},
       // Performance group.
       {id: 'gpt-bids-parallel', weight: 1, group: 'ads-performance'},
       {id: 'serial-header-bidding', weight: 1, group: 'ads-performance'},
@@ -72,8 +72,8 @@ module.exports = {
       {id: 'ads-in-viewport', weight: 4, group: 'ads-best-practices'},
       {id: 'async-ad-tags', weight: 2, group: 'ads-best-practices'},
       {id: 'loads-ad-tag-over-https', weight: 1, group: 'ads-best-practices'},
-      {id: 'loads-gpt-from-sgdn', weight: 1, group: 'ads-best-practices'},
-      {id: 'viewport-ad-density', weight: 1, group: 'ads-best-practices'},
+      {id: 'loads-gpt-from-sgdn', weight: 4, group: 'ads-best-practices'},
+      {id: 'viewport-ad-density', weight: 2, group: 'ads-best-practices'},
       {id: 'ad-top-of-viewport', weight: 2, group: 'ads-best-practices'},
       {id: 'duplicate-tags', weight: 1, group: 'ads-best-practices'},
     ],


### PR DESCRIPTION

audit_id | initial_weight | initial_pct | updated_weight | updated_pct | pct_diff
-- | -- | -- | -- | -- | --
tag-load-time | 4 | 11.43% | 4 | 7.02% | -4.41%
bid-request-from-page-start | 4 | 11.43% | 4 | 7.02% | -4.41%
ad-request-from-page-start | 4 | 11.43% | 20 | 35.09% | 23.66%
first-ad-render | 8 | 22.86% | 10 | 17.54% | -5.31%
gpt-bids-parallel | 1 | 2.86% | 1 | 1.75% | -1.10%
serial-header-bidding | 1 | 2.86% | 1 | 1.75% | -1.10%
bottleneck-requests | 1 | 2.86% | 1 | 1.75% | -1.10%
script-injected-tags | 1 | 2.86% | 1 | 1.75% | -1.10%
blocking-load-events | 1 | 2.86% | 1 | 1.75% | -1.10%
ad-render-blocking-resources | 1 | 2.86% | 1 | 1.75% | -1.10%
ad-blocking-tasks | 1 | 2.86% | 1 | 1.75% | -1.10%
ad-request-critical-path | 0 | 0.00% | 0 | 0.00% | 0.00%
ads-in-viewport | 4 | 11.43% | 4 | 7.02% | -4.41%
async-ad-tags | 2 | 5.71% | 2 | 3.51% | -2.21%
loads-ad-tag-over-https | 1 | 2.86% | 1 | 1.75% | -1.10%
loads-gpt-from-sgdn | 1 | 2.86% | 4 | 7.02% | 4.16%
viewport-ad-density | 1 | 2.86% | 2 | 3.51% | 0.65%
ad-top-of-viewport | 2 | 5.71% | 2 | 3.51% | -2.21%
duplicate-tags | 1 | 2.86% | 1 | 1.75% | -1.10%

