### PR TITLE
Fixes AdSense impl tag regex to handle version number.

### DIFF
--- a/lighthouse-plugin-publisher-ads/audits/ads-in-viewport.js
+++ b/lighthouse-plugin-publisher-ads/audits/ads-in-viewport.js
@@ -16,8 +16,8 @@ const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 
 const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
-const {isAdIframe} = require('../utils/resource-classification');
 const {isBoxInViewport} = require('../utils/geometry');
+const {isGptIframe} = require('../utils/resource-classification');
 
 const UIStrings = {
   title: 'Few or no ads loaded outside viewport',
@@ -67,7 +67,7 @@ class AdsInViewport extends Audit {
   static audit(artifacts) {
     const viewport = artifacts.ViewportDimensions;
     const slots = artifacts.IFrameElements
-        .filter((iframe) => isAdIframe(iframe) &&
+        .filter((iframe) => isGptIframe(iframe) &&
           iframe.clientRect.height * iframe.clientRect.width > 1);
 
     if (!slots.length) {

--- a/lighthouse-plugin-publisher-ads/utils/resource-classification.js
+++ b/lighthouse-plugin-publisher-ads/utils/resource-classification.js
@@ -61,7 +61,7 @@ function isAdSenseImplTag(url) {
   url = toURL(url);
   const matchesHost = url.host === 'pagead2.googlesyndication.com';
   const matchesPath =
-      /(^\/pagead\/js\/.*\/show_ads_impl\.js)/.test(url.pathname);
+      /(^\/pagead\/js\/.*\/show_ads_impl.*?\.js)/.test(url.pathname);
   return matchesHost && matchesPath;
 }
 


### PR DESCRIPTION
Also makes ads in viewport audit ignore AdSense iframes placed out of viewport.