### PR TITLE
Upgrade to Lighthouse 6.0.0-beta.0

### DIFF
--- a/lighthouse-plugin-publisher-ads/audits/ad-blocking-tasks.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-blocking-tasks.js
@@ -162,6 +162,7 @@ class AdBlockingTasks extends Audit {
     return {
       score: failed ? 0 : 1,
       numericValue: blockedTime,
+      numericUnit: 'millisecond',
       displayValue: failed ?
         str_(UIStrings.failureDisplayValue, {timeInMs: blockedTime}) :
         '',

--- a/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
@@ -156,6 +156,7 @@ class AdRenderBlockingResources extends Audit {
     return {
       score: failed ? 0 : 1,
       numericValue: tableView.length,
+      numericUnit: 'unitless',
       displayValue,
       details: {
         opportunity,

--- a/lighthouse-plugin-publisher-ads/audits/ad-request-critical-path.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-critical-path.js
@@ -166,6 +166,7 @@ class AdRequestCriticalPath extends Audit {
 
     return {
       numericValue: depth,
+      numericUnit: 'unitless',
       score: failed ? 0 : 1,
       displayValue: str_(UIStrings.displayValue, {serialResources: depth}),
       details: {

--- a/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
@@ -61,10 +61,14 @@ class AdRequestFromPageStart extends Audit {
       simulate: {
         scorePODR: 3500,
         scoreMedian: 8000,
+        // Derived from the existing PODR and median points.
+        p10: 4350,
       },
       provided: {
         scorePODR: 1500,
         scoreMedian: 3500,
+        // Derived from the existing PODR and median points.
+        p10: 1900,
       },
     };
   }
@@ -93,9 +97,8 @@ class AdRequestFromPageStart extends Audit {
     return {
       numericValue: timing * 1e-3,
       score: Audit.computeLogNormalScore(
-        timing,
-        scoreOptions.scorePODR,
-        scoreOptions.scoreMedian
+        {p10: scoreOptions.p10, median: scoreOptions.scoreMedian},
+        timing
       ),
       displayValue: str_(UIStrings.displayValue, {timeInMs: timing}),
     };

--- a/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
@@ -90,8 +90,9 @@ class AdRequestFromPageStart extends Audit {
 
     const {timing} = await ComputedAdRequestTime.request(metricData, context);
     if (!(timing > 0)) { // Handle NaN, etc.
-      context.LighthouseRunWarnings.push(runWarning.NoAds);
-      return auditNotApplicable.NoAds;
+      const naAuditProduct = auditNotApplicable.NoAds;
+      naAuditProduct.runWarnings = [runWarning.NoAds];
+      return naAuditProduct;
     }
 
     return {

--- a/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
@@ -97,6 +97,7 @@ class AdRequestFromPageStart extends Audit {
 
     return {
       numericValue: timing * 1e-3,
+      numericUnit: 'millisecond',
       score: Audit.computeLogNormalScore(
         {p10: scoreOptions.p10, median: scoreOptions.scoreMedian},
         timing

--- a/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
@@ -57,18 +57,13 @@ class AdRequestFromPageStart extends Audit {
     */
   static get defaultOptions() {
     return {
-      // 75th & 95th percentile with simulation.
       simulate: {
-        scorePODR: 3500,
-        scoreMedian: 8000,
-        // Derived from the existing PODR and median points.
         p10: 4350,
+        median: 8000,
       },
       provided: {
-        scorePODR: 1500,
-        scoreMedian: 3500,
-        // Derived from the existing PODR and median points.
         p10: 1900,
+        median: 3500,
       },
     };
   }
@@ -99,7 +94,7 @@ class AdRequestFromPageStart extends Audit {
       numericValue: timing * 1e-3,
       numericUnit: 'millisecond',
       score: Audit.computeLogNormalScore(
-        {p10: scoreOptions.p10, median: scoreOptions.scoreMedian},
+        scoreOptions,
         timing
       ),
       displayValue: str_(UIStrings.displayValue, {timeInMs: timing}),

--- a/lighthouse-plugin-publisher-ads/audits/ad-request-from-tag-load.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-from-tag-load.js
@@ -78,6 +78,7 @@ class AdRequestFromTagLoad extends Audit {
 
     return {
       numericValue: adReqTimeMs * 1e-3,
+      numericUnit: 'unitless',
       score: Audit.computeLogNormalScore({p10: P10, median: MEDIAN},
         adReqTimeMs),
       displayValue: str_(UIStrings.displayValue, {timeInMs: adReqTimeMs}),

--- a/lighthouse-plugin-publisher-ads/audits/ad-request-from-tag-load.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-from-tag-load.js
@@ -32,6 +32,7 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 // Point of diminishing returns.
 const PODR = 300; // ms
 const MEDIAN = 1000; // ms
+const P10 = 450; // ms
 
 /**
  * Audit to determine time for first ad request relative to tag load.
@@ -79,7 +80,8 @@ class AdRequestFromTagLoad extends Audit {
 
     return {
       numericValue: adReqTimeMs * 1e-3,
-      score: Audit.computeLogNormalScore(adReqTimeMs, PODR, MEDIAN),
+      score: Audit.computeLogNormalScore({p10: P10, median: MEDIAN},
+        adReqTimeMs),
       displayValue: str_(UIStrings.displayValue, {timeInMs: adReqTimeMs}),
     };
   }

--- a/lighthouse-plugin-publisher-ads/audits/ad-request-from-tag-load.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-from-tag-load.js
@@ -29,10 +29,8 @@ const UIStrings = {
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
-// Point of diminishing returns.
-const PODR = 300; // ms
-const MEDIAN = 1000; // ms
 const P10 = 450; // ms
+const MEDIAN = 1000; // ms
 
 /**
  * Audit to determine time for first ad request relative to tag load.

--- a/lighthouse-plugin-publisher-ads/audits/ad-top-of-viewport.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-top-of-viewport.js
@@ -93,6 +93,7 @@ class AdTopOfViewport extends Audit {
     return {
       score,
       numericValue: topSlot.midpoint,
+      numericUnit: 'unitless',
       // No displayValue if passing, no changes to be made.
       displayValue: score ? '' :
         str_(UIStrings.failureDisplayValue, {valueInPx: topSlot.midpoint}),

--- a/lighthouse-plugin-publisher-ads/audits/ads-in-viewport.js
+++ b/lighthouse-plugin-publisher-ads/audits/ads-in-viewport.js
@@ -84,6 +84,7 @@ class AdsInViewport extends Audit {
 
     return {
       numericValue: visibleCount / slots.length,
+      numericUnit: 'unitless',
       score: nonvisible.length > 3 ? 0 : 1,
       displayValue: nonvisible.length ?
         str_(UIStrings.failureDisplayValue, {hiddenAds: nonvisible.length}) :

--- a/lighthouse-plugin-publisher-ads/audits/async-ad-tags.js
+++ b/lighthouse-plugin-publisher-ads/audits/async-ad-tags.js
@@ -84,6 +84,7 @@ class AsyncAdTags extends Audit {
     return {
       score: Number(passed),
       numericValue: numSync,
+      numericUnit: 'unitless',
     };
   }
 }

--- a/lighthouse-plugin-publisher-ads/audits/bid-request-from-page-start.js
+++ b/lighthouse-plugin-publisher-ads/audits/bid-request-from-page-start.js
@@ -59,17 +59,12 @@ class BidRequestFromPageStart extends Audit {
   static get defaultOptions() {
     return {
       simulate: {
-        // 75th & 95th percentile with simulation.
-        scorePODR: 7500,
-        scoreMedian: 15500,
-        // Derived from the existing PODR and median points.
         p10: 8900,
+        median: 15500,
       },
       provided: {
-        scorePODR: 1500,
-        scoreMedian: 3500,
-        // Derived from the existing PODR and median points.
         p10: 1900,
+        median: 3500,
       },
     };
   }
@@ -97,7 +92,7 @@ class BidRequestFromPageStart extends Audit {
     return {
       numericValue: timing * 1e-3,
       score: Audit.computeLogNormalScore(
-        {p10: scoreOptions.p10, median: scoreOptions.scoreMedian},
+        scoreOptions,
         timing
       ),
       displayValue: str_(UIStrings.displayValue, {timeInMs: timing}),

--- a/lighthouse-plugin-publisher-ads/audits/bid-request-from-page-start.js
+++ b/lighthouse-plugin-publisher-ads/audits/bid-request-from-page-start.js
@@ -91,6 +91,7 @@ class BidRequestFromPageStart extends Audit {
 
     return {
       numericValue: timing * 1e-3,
+      numericUnit: 'millisecond',
       score: Audit.computeLogNormalScore(
         scoreOptions,
         timing

--- a/lighthouse-plugin-publisher-ads/audits/bid-request-from-page-start.js
+++ b/lighthouse-plugin-publisher-ads/audits/bid-request-from-page-start.js
@@ -62,10 +62,14 @@ class BidRequestFromPageStart extends Audit {
         // 75th & 95th percentile with simulation.
         scorePODR: 7500,
         scoreMedian: 15500,
+        // Derived from the existing PODR and median points.
+        p10: 8900,
       },
       provided: {
         scorePODR: 1500,
         scoreMedian: 3500,
+        // Derived from the existing PODR and median points.
+        p10: 1900,
       },
     };
   }
@@ -93,9 +97,8 @@ class BidRequestFromPageStart extends Audit {
     return {
       numericValue: timing * 1e-3,
       score: Audit.computeLogNormalScore(
-        timing,
-        scoreOptions.scorePODR,
-        scoreOptions.scoreMedian
+        {p10: scoreOptions.p10, median: scoreOptions.scoreMedian},
+        timing
       ),
       displayValue: str_(UIStrings.displayValue, {timeInMs: timing}),
     };

--- a/lighthouse-plugin-publisher-ads/audits/blocking-load-events.js
+++ b/lighthouse-plugin-publisher-ads/audits/blocking-load-events.js
@@ -237,6 +237,7 @@ class BlockingLoadEvents extends Audit {
     }
     return {
       numericValue: blockingEvents.length,
+      numericUnit: 'unitless',
       score: failed ? 0 : 1,
       displayValue: failed && blockedTime ?
         str_(UIStrings.displayValue, {timeInMs: blockedTime}) :

--- a/lighthouse-plugin-publisher-ads/audits/bottleneck-requests.js
+++ b/lighthouse-plugin-publisher-ads/audits/bottleneck-requests.js
@@ -120,6 +120,7 @@ class BottleneckRequests extends Audit {
     }
     return {
       numericValue: criticalRequests.length,
+      numericUnit: 'unitless',
       score: failed ? 0 : 1,
       displayValue: failed ? str_(UIStrings.displayValue, {blockedTime}) : '',
       details:

--- a/lighthouse-plugin-publisher-ads/audits/duplicate-tags.js
+++ b/lighthouse-plugin-publisher-ads/audits/duplicate-tags.js
@@ -107,6 +107,7 @@ class DuplicateTags extends Audit {
 
     return {
       numericValue: dups.length,
+      numericUnit: 'unitless',
       score: dups.length ? 0 : 1,
       details: DuplicateTags.makeTableDetails(HEADINGS, dups),
       displayValue: dups.length ?

--- a/lighthouse-plugin-publisher-ads/audits/first-ad-render.js
+++ b/lighthouse-plugin-publisher-ads/audits/first-ad-render.js
@@ -104,8 +104,9 @@ class FirstAdRender extends Audit {
     const {timing} = await ComputedAdRenderTime.request(metricData, context);
 
     if (!(timing > 0)) { // Handle NaN, etc.
-      context.LighthouseRunWarnings.push(runWarning.NoAdRendered);
-      return auditNotApplicable.NoAdRendered;
+      const naAuditProduct = auditNotApplicable.NoAdRendered;
+      naAuditProduct.runWarnings = [runWarning.NoAdRendered];
+      return naAuditProduct;
     }
 
     let scoreOptions = context.options[

--- a/lighthouse-plugin-publisher-ads/audits/first-ad-render.js
+++ b/lighthouse-plugin-publisher-ads/audits/first-ad-render.js
@@ -121,6 +121,7 @@ class FirstAdRender extends Audit {
 
     return {
       numericValue: timing * 1e-3,
+      numericUnit: 'millisecond',
       score: Audit.computeLogNormalScore(
         {p10: scoreOptions.p10, median: scoreOptions.scoreMedian},
         timing

--- a/lighthouse-plugin-publisher-ads/audits/first-ad-render.js
+++ b/lighthouse-plugin-publisher-ads/audits/first-ad-render.js
@@ -65,6 +65,8 @@ class FirstAdRender extends Audit {
         default: {
           scorePODR: 8500,
           scoreMedian: 15000,
+          // Derived from the existing PODR and median points.
+          p10: 9400,
         },
         // 75th & 95th percentile with simulation.
         // Specific to LR due to patch of
@@ -73,11 +75,15 @@ class FirstAdRender extends Audit {
         lightrider: {
           scorePODR: 11000,
           scoreMedian: 22000,
+          // Derived from the existing PODR and median points.
+          p10: 12900,
         },
       },
       provided: {
         scorePODR: 2700,
         scoreMedian: 3700,
+        // Derived from the existing PODR and median points.
+        p10: 2750,
       },
 
     };
@@ -115,9 +121,8 @@ class FirstAdRender extends Audit {
     return {
       numericValue: timing * 1e-3,
       score: Audit.computeLogNormalScore(
-        timing,
-        scoreOptions.scorePODR,
-        scoreOptions.scoreMedian
+        {p10: scoreOptions.p10, median: scoreOptions.scoreMedian},
+        timing
       ),
       displayValue:
         str_(UIStrings.displayValue, {timeInMs: timing}),

--- a/lighthouse-plugin-publisher-ads/audits/first-ad-render.js
+++ b/lighthouse-plugin-publisher-ads/audits/first-ad-render.js
@@ -53,37 +53,19 @@ class FirstAdRender extends Audit {
 
   /**
    * @return {{
-   *   simulate: {
-   *    default: LH.Audit.ScoreOptions, lightrider: LH.Audit.ScoreOptions
-   *   },
+   *   simulate: LH.Audit.ScoreOptions,
    *   provided: LH.Audit.ScoreOptions
    * }}
    */
   static get defaultOptions() {
     return {
       simulate: {
-        default: {
-          scorePODR: 8500,
-          scoreMedian: 15000,
-          // Derived from the existing PODR and median points.
-          p10: 9400,
-        },
-        // 75th & 95th percentile with simulation.
-        // Specific to LR due to patch of
-        // https://github.com/GoogleChrome/lighthouse/pull/9910. Will update
-        // values after next LH release.
-        lightrider: {
-          scorePODR: 11000,
-          scoreMedian: 22000,
-          // Derived from the existing PODR and median points.
-          p10: 12900,
-        },
+        p10: 12900,
+        median: 22000,
       },
       provided: {
-        scorePODR: 2700,
-        scoreMedian: 3700,
-        // Derived from the existing PODR and median points.
         p10: 2750,
+        median: 3700,
       },
 
     };
@@ -109,21 +91,17 @@ class FirstAdRender extends Audit {
       return naAuditProduct;
     }
 
-    let scoreOptions = context.options[
+    const scoreOptions = context.options[
         context.settings.throttlingMethod == 'provided' ?
           'provided' :
           'simulate'
     ];
-    if (scoreOptions.lightrider) {
-      scoreOptions =
-        scoreOptions[global.isLightrider ? 'lightrider' : 'default'];
-    }
 
     return {
       numericValue: timing * 1e-3,
       numericUnit: 'millisecond',
       score: Audit.computeLogNormalScore(
-        {p10: scoreOptions.p10, median: scoreOptions.scoreMedian},
+        scoreOptions,
         timing
       ),
       displayValue:

--- a/lighthouse-plugin-publisher-ads/audits/full-width-slots.js
+++ b/lighthouse-plugin-publisher-ads/audits/full-width-slots.js
@@ -92,6 +92,7 @@ class FullWidthSlots extends Audit {
     return {
       score,
       numericValue: pctUnoccupied,
+      numericUnit: 'unitless',
       // No displayValue if passing, no changes to be made.
       displayValue: score ?
         '' :

--- a/lighthouse-plugin-publisher-ads/audits/gpt-bids-parallel.js
+++ b/lighthouse-plugin-publisher-ads/audits/gpt-bids-parallel.js
@@ -115,6 +115,7 @@ class GptBidsInParallel extends Audit {
     const failed = tableView.length > 0;
     return {
       numericValue: tableView.length,
+      numericUnit: 'unitless',
       score: failed ? 0 : 1,
       details: failed ?
         GptBidsInParallel.makeTableDetails(HEADINGS, tableView) : undefined,

--- a/lighthouse-plugin-publisher-ads/audits/idle-network-times.js
+++ b/lighthouse-plugin-publisher-ads/audits/idle-network-times.js
@@ -146,7 +146,8 @@ function checkIfTaskIsBlocking(idlePeriod, mainThreadTasks, timerEvents) {
     // Check if timer is blocking.
     if (task.event.name == 'TimerFire' &&
         idlePeriod.endTime - task.startTime < PROXIMITY_MS_THRESHOLD) {
-      const timerId = task.event.args.data.timerId;
+      const timerId =
+        task.event.args.data && task.event.args.data.timerId || '';
       const start = timerEvents.find((t) =>
         // @ts-ignore
         t.name == 'TimerInstall' && t.args.data.timerId == timerId);
@@ -313,6 +314,7 @@ class IdleNetworkTimes extends Audit {
 
     return {
       numericValue: maxIdleTime,
+      numericUnit: 'millisecond',
       score: failed ? 0 : 1,
       displayValue:
         str_(UIStrings.displayValue, {timeInMs: (totalIdleTime)}),

--- a/lighthouse-plugin-publisher-ads/audits/loads-gpt-from-sgdn.js
+++ b/lighthouse-plugin-publisher-ads/audits/loads-gpt-from-sgdn.js
@@ -67,6 +67,7 @@ class LoadsGptFromSgdn extends Audit {
     return {
       score: Number(passed),
       numericValue: Number(!passed),
+      numericUnit: 'unitless',
     };
   }
 }

--- a/lighthouse-plugin-publisher-ads/audits/script-injected-tags.js
+++ b/lighthouse-plugin-publisher-ads/audits/script-injected-tags.js
@@ -179,6 +179,7 @@ class StaticAdTags extends Audit {
         str_(UIStrings.failureDisplayValue, {tags: tableView.length}) : '',
       score: Number(!failed),
       numericValue: tableView.length,
+      numericUnit: 'unitless',
       details: StaticAdTags.makeTableDetails(HEADINGS, tableView),
     };
   }

--- a/lighthouse-plugin-publisher-ads/audits/serial-header-bidding.js
+++ b/lighthouse-plugin-publisher-ads/audits/serial-header-bidding.js
@@ -235,6 +235,7 @@ class SerialHeaderBidding extends Audit {
     const hasSerialHeaderBidding = serialBids.length > 1;
     return {
       numericValue: Number(hasSerialHeaderBidding),
+      numericUnit: 'unitless',
       score: hasSerialHeaderBidding ? 0 : 1,
       details: hasSerialHeaderBidding ?
         SerialHeaderBidding.makeTableDetails(HEADINGS, serialBids) : undefined,

--- a/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
+++ b/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
@@ -90,8 +90,9 @@ class TagLoadTime extends Audit {
 
     const {timing} = await ComputedTagLoadTime.request(metricData, context);
     if (!(timing > 0)) { // Handle NaN, etc.
-      context.LighthouseRunWarnings.push(runWarning.NoTag);
-      return auditNotApplicable.NoTag;
+      const naAuditProduct = auditNotApplicable.NoTag;
+      naAuditProduct.runWarnings = [runWarning.NoTag];
+      return naAuditProduct;
     }
 
     // NOTE: score is relative to page response time to avoid counting time for

--- a/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
+++ b/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
@@ -99,6 +99,7 @@ class TagLoadTime extends Audit {
     // first party rendering.
     return {
       numericValue: timing * 1e-3, // seconds
+      numericUnit: 'millisecond', // TODO: seconds or ms ???????/
       score: Audit.computeLogNormalScore(
         {p10: scoreOptions.p10, median: scoreOptions.scoreMedian},
         timing

--- a/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
+++ b/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
@@ -61,10 +61,14 @@ class TagLoadTime extends Audit {
         // 75th & 95th percentile with simulation.
         scorePODR: 6000,
         scoreMedian: 10000,
+        // Derived from the existing PODR and median points.
+        p10: 6500,
       },
       provided: {
         scorePODR: 1000,
         scoreMedian: 2000,
+        // Derived from the existing PODR and median points.
+        p10: 1200,
       },
     };
   }
@@ -95,9 +99,8 @@ class TagLoadTime extends Audit {
     return {
       numericValue: timing * 1e-3, // seconds
       score: Audit.computeLogNormalScore(
-        timing,
-        scoreOptions.scorePODR,
-        scoreOptions.scoreMedian
+        {p10: scoreOptions.p10, median: scoreOptions.scoreMedian},
+        timing
       ),
       displayValue: str_(UIStrings.displayValue, {timeInMs: timing}),
     };

--- a/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
+++ b/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
@@ -58,17 +58,12 @@ class TagLoadTime extends Audit {
   static get defaultOptions() {
     return {
       simulate: {
-        // 75th & 95th percentile with simulation.
-        scorePODR: 6000,
-        scoreMedian: 10000,
-        // Derived from the existing PODR and median points.
         p10: 6500,
+        median: 10000,
       },
       provided: {
-        scorePODR: 1000,
-        scoreMedian: 2000,
-        // Derived from the existing PODR and median points.
         p10: 1200,
+        median: 2000,
       },
     };
   }
@@ -101,7 +96,7 @@ class TagLoadTime extends Audit {
       numericValue: timing * 1e-3, // seconds => ms
       numericUnit: 'millisecond',
       score: Audit.computeLogNormalScore(
-        {p10: scoreOptions.p10, median: scoreOptions.scoreMedian},
+        scoreOptions,
         timing
       ),
       displayValue: str_(UIStrings.displayValue, {timeInMs: timing}),

--- a/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
+++ b/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
@@ -98,8 +98,8 @@ class TagLoadTime extends Audit {
     // NOTE: score is relative to page response time to avoid counting time for
     // first party rendering.
     return {
-      numericValue: timing * 1e-3, // seconds
-      numericUnit: 'millisecond', // TODO: seconds or ms ???????/
+      numericValue: timing * 1e-3, // seconds => ms
+      numericUnit: 'millisecond',
       score: Audit.computeLogNormalScore(
         {p10: scoreOptions.p10, median: scoreOptions.scoreMedian},
         timing

--- a/lighthouse-plugin-publisher-ads/audits/viewport-ad-density.js
+++ b/lighthouse-plugin-publisher-ads/audits/viewport-ad-density.js
@@ -80,6 +80,7 @@ class ViewportAdDensity extends Audit {
     return {
       score,
       numericValue: adArea / viewArea,
+      numericUnit: 'unitless',
       displayValue: str_(UIStrings.displayValue, {adDensity}),
     };
   }

--- a/lighthouse-plugin-publisher-ads/computed/long-tasks.js
+++ b/lighthouse-plugin-publisher-ads/computed/long-tasks.js
@@ -96,6 +96,9 @@ class LongTasks extends ComputedMetric {
         selfTime: timing.duration, // TODO: subtract child time
         attributableURLs: Array.from(node.getEvaluateScriptURLs()),
         children: [],
+        parent: node.parent,
+        unbounded: node.unbounded,
+        group: node.group,
       });
     }
     return tasks;

--- a/lighthouse-plugin-publisher-ads/messages/common-strings.js
+++ b/lighthouse-plugin-publisher-ads/messages/common-strings.js
@@ -47,7 +47,7 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 /**
  * Returns object for a notApplicable audit given a message string
  * @param {string} message
- * @return {Object}
+ * @return {LH.Audit.Product}
  */
 const notApplicableObj = (message) => ({
   notApplicable: true,
@@ -57,7 +57,7 @@ const notApplicableObj = (message) => ({
 
 /**
  * Returns notApplicable object for a given property.
- * @return {Object}
+ * @return {LH.Audit.Product}
  */
 const auditNotApplicable = {
   Default: notApplicableObj(UIStrings.NOT_APPLICABLE__DEFAULT),

--- a/lighthouse-plugin-publisher-ads/package.json
+++ b/lighthouse-plugin-publisher-ads/package.json
@@ -32,7 +32,7 @@
     "yargs": "^13.3.0"
   },
   "peerDependencies": {
-    "lighthouse": ">=5.6.0"
+    "lighthouse": ">=6.0.0-beta.0"
   },
   "devDependencies": {
     "@types/yargs": "^12.0.1",

--- a/lighthouse-plugin-publisher-ads/typings/lighthouse.d.ts
+++ b/lighthouse-plugin-publisher-ads/typings/lighthouse.d.ts
@@ -50,9 +50,8 @@ declare module 'lighthouse' {
       static get DEFAULT_PASS(): string;
 
       static computeLogNormalScore(
-        measuredValue : number,
-        diminishingReturnsValue: number,
-        medianValue: number
+        controlPoints : {median: number, p10: number},
+        value: number,
       ): number;
     }
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@tusbar/cache-control": "^0.3.1",
     "@types/esprima": "^4.0.2",
-    "lighthouse": "^5.6.0",
+    "lighthouse": "^6.0.0-beta.0",
     "yargs": "^13.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@tusbar/cache-control": "^0.3.1",
     "@types/esprima": "^4.0.2",
-    "lighthouse": "^6.0.0-beta.0",
+    "lighthouse": "^5.6.0",
     "yargs": "^13.3.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -209,10 +209,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.3.0.tgz#3b32d7e54390d89ff4891b20394d33ad7a192776"
-  integrity sha512-54XaTd2VB7A6iBnXMUG2LnBOI7aRbnrVxC5Tz+rVUwYl9MX/cIJc/Ll32YUoFIE/e9UKWMZoQenQu9dFrQyZCg==
+axe-core@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.1.tgz#d8d5aaef73f003e8b766ea28bb078343f3622201"
+  integrity sha512-mwpDgPwWB+5kMHyLjlxh4w25ClJfqSxi+c6LQ4ix349TdCUctMwJNPTkhPD1qP9SYIjFgjeVpVZWCvK9oBGwCg==
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -358,10 +358,10 @@ check-error@^1.0.2:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
-chrome-launcher@^0.11.2:
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.11.2.tgz#c9a248dbccd3a08565553acf61adff879bcc982c"
-  integrity sha512-jx0kJDCXdB2ARcDMwNCtrf04oY1Up4rOmVu+fqJ5MTPOOIG8EhRcEU9NZfXZc6dMw9FU8o1r21PNp8V2M0zQ+g==
+chrome-launcher@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.12.0.tgz#08db81ef0f7b283c331df2c350e780c38bd0ce3a"
+  integrity sha512-rBUP4tvWToiileDi3UR0SbWKoUoDCYTRmVND2sdoBL1xANBgVz8V9h1yQluj3MEQaBJg0fRw7hW82uOPrJus7A==
   dependencies:
     "@types/node" "*"
     is-wsl "^2.1.0"
@@ -1344,10 +1344,10 @@ jpeg-js@0.1.2, jpeg-js@^0.1.2:
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.1.2.tgz#135b992c0575c985cfa0f494a3227ed238583ece"
   integrity sha1-E1uZLAV1yYXPoPSUoyJ+0jhYPs4=
 
-js-library-detector@^5.5.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/js-library-detector/-/js-library-detector-5.6.0.tgz#a44c95237870b5e4f66f0aff948270df7ec9f277"
-  integrity sha512-s9LeTXee2J+7qXQHJ1EHPbK4Mk5ZU820Wrw+EOxDRQcn2Tay4n+SvZaqJa6T8UpKu5mIomSh6nXoyuP1j2DzUw==
+js-library-detector@^5.7.0:
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/js-library-detector/-/js-library-detector-5.9.0.tgz#ad0add7f4991424326895b273e774876555d0e1b"
+  integrity sha512-0wYHRVJv8uVsylJhfQQaH2vOBYGehyZyJbtaHuchoTP3Mb6hqYvrA0hoMQ1ZhARLHzHJMbMc/nCr4D3pTNSCgw==
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -1457,13 +1457,13 @@ lighthouse-logger@^1.0.0, lighthouse-logger@^1.2.0:
     debug "^2.6.8"
     marky "^1.2.0"
 
-lighthouse@^5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/lighthouse/-/lighthouse-5.6.0.tgz#2182e0d9bc79783bc9d801dd5099a33526dabdd0"
-  integrity sha512-PQYeK6/P0p/JxP/zq8yfcPmuep/aeib5ykROTgzDHejMiuzYdD6k6MaSCv0ncwK+lj+Ld67Az+66rHqiPKHc6g==
+lighthouse@^6.0.0-beta.0:
+  version "6.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/lighthouse/-/lighthouse-6.0.0-beta.0.tgz#587293bd08feeaa9ad8bcd884cd97db42a72f48a"
+  integrity sha512-YdVnnCItI5DsuvV9ECv4om4vfSJZ1MeLNBP+QWTuFzV24/K73J0zx3oO6QzbGfuaPlbJfVv5/FPOqgRCjdWiFw==
   dependencies:
-    axe-core "3.3.0"
-    chrome-launcher "^0.11.2"
+    axe-core "3.5.1"
+    chrome-launcher "^0.12.0"
     configstore "^3.1.1"
     cssstyle "1.2.1"
     details-element-polyfill "^2.4.0"
@@ -1473,7 +1473,7 @@ lighthouse@^5.6.0:
     intl-messageformat "^4.4.0"
     intl-pluralrules "^1.0.3"
     jpeg-js "0.1.2"
-    js-library-detector "^5.5.0"
+    js-library-detector "^5.7.0"
     jsonld "^1.5.0"
     jsonlint-mod "^1.7.5"
     lighthouse-logger "^1.2.0"
@@ -1481,7 +1481,6 @@ lighthouse@^5.6.0:
     lodash.set "^4.3.2"
     lookup-closest-locale "6.0.4"
     metaviewport-parser "0.2.0"
-    mkdirp "0.5.1"
     open "^6.4.0"
     parse-cache-control "1.0.1"
     raven "^2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -209,10 +209,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.1.tgz#d8d5aaef73f003e8b766ea28bb078343f3622201"
-  integrity sha512-mwpDgPwWB+5kMHyLjlxh4w25ClJfqSxi+c6LQ4ix349TdCUctMwJNPTkhPD1qP9SYIjFgjeVpVZWCvK9oBGwCg==
+axe-core@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.3.0.tgz#3b32d7e54390d89ff4891b20394d33ad7a192776"
+  integrity sha512-54XaTd2VB7A6iBnXMUG2LnBOI7aRbnrVxC5Tz+rVUwYl9MX/cIJc/Ll32YUoFIE/e9UKWMZoQenQu9dFrQyZCg==
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -358,10 +358,10 @@ check-error@^1.0.2:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
-chrome-launcher@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.12.0.tgz#08db81ef0f7b283c331df2c350e780c38bd0ce3a"
-  integrity sha512-rBUP4tvWToiileDi3UR0SbWKoUoDCYTRmVND2sdoBL1xANBgVz8V9h1yQluj3MEQaBJg0fRw7hW82uOPrJus7A==
+chrome-launcher@^0.11.2:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.11.2.tgz#c9a248dbccd3a08565553acf61adff879bcc982c"
+  integrity sha512-jx0kJDCXdB2ARcDMwNCtrf04oY1Up4rOmVu+fqJ5MTPOOIG8EhRcEU9NZfXZc6dMw9FU8o1r21PNp8V2M0zQ+g==
   dependencies:
     "@types/node" "*"
     is-wsl "^2.1.0"
@@ -1344,10 +1344,10 @@ jpeg-js@0.1.2, jpeg-js@^0.1.2:
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.1.2.tgz#135b992c0575c985cfa0f494a3227ed238583ece"
   integrity sha1-E1uZLAV1yYXPoPSUoyJ+0jhYPs4=
 
-js-library-detector@^5.7.0:
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/js-library-detector/-/js-library-detector-5.9.0.tgz#ad0add7f4991424326895b273e774876555d0e1b"
-  integrity sha512-0wYHRVJv8uVsylJhfQQaH2vOBYGehyZyJbtaHuchoTP3Mb6hqYvrA0hoMQ1ZhARLHzHJMbMc/nCr4D3pTNSCgw==
+js-library-detector@^5.5.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/js-library-detector/-/js-library-detector-5.6.0.tgz#a44c95237870b5e4f66f0aff948270df7ec9f277"
+  integrity sha512-s9LeTXee2J+7qXQHJ1EHPbK4Mk5ZU820Wrw+EOxDRQcn2Tay4n+SvZaqJa6T8UpKu5mIomSh6nXoyuP1j2DzUw==
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -1457,13 +1457,13 @@ lighthouse-logger@^1.0.0, lighthouse-logger@^1.2.0:
     debug "^2.6.8"
     marky "^1.2.0"
 
-lighthouse@^6.0.0-beta.0:
-  version "6.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/lighthouse/-/lighthouse-6.0.0-beta.0.tgz#587293bd08feeaa9ad8bcd884cd97db42a72f48a"
-  integrity sha512-YdVnnCItI5DsuvV9ECv4om4vfSJZ1MeLNBP+QWTuFzV24/K73J0zx3oO6QzbGfuaPlbJfVv5/FPOqgRCjdWiFw==
+lighthouse@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/lighthouse/-/lighthouse-5.6.0.tgz#2182e0d9bc79783bc9d801dd5099a33526dabdd0"
+  integrity sha512-PQYeK6/P0p/JxP/zq8yfcPmuep/aeib5ykROTgzDHejMiuzYdD6k6MaSCv0ncwK+lj+Ld67Az+66rHqiPKHc6g==
   dependencies:
-    axe-core "3.5.1"
-    chrome-launcher "^0.12.0"
+    axe-core "3.3.0"
+    chrome-launcher "^0.11.2"
     configstore "^3.1.1"
     cssstyle "1.2.1"
     details-element-polyfill "^2.4.0"
@@ -1473,7 +1473,7 @@ lighthouse@^6.0.0-beta.0:
     intl-messageformat "^4.4.0"
     intl-pluralrules "^1.0.3"
     jpeg-js "0.1.2"
-    js-library-detector "^5.7.0"
+    js-library-detector "^5.5.0"
     jsonld "^1.5.0"
     jsonlint-mod "^1.7.5"
     lighthouse-logger "^1.2.0"
@@ -1481,6 +1481,7 @@ lighthouse@^6.0.0-beta.0:
     lodash.set "^4.3.2"
     lookup-closest-locale "6.0.4"
     metaviewport-parser "0.2.0"
+    mkdirp "0.5.1"
     open "^6.4.0"
     parse-cache-control "1.0.1"
     raven "^2.2.1"


### PR DESCRIPTION
- Include 10th percentile scores to support Lighthouse v6.0 `computeLogNormalScore` changes (thanks @brendankenny!).
- Update runWarnings usage (thanks @paulirish!).
- Include numericUnits.
- Other minor fixes.