### PR TITLE
Additional 6.0 fixes

### DIFF
--- a/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
@@ -90,8 +90,9 @@ class AdRequestFromPageStart extends Audit {
 
     const {timing} = await ComputedAdRequestTime.request(metricData, context);
     if (!(timing > 0)) { // Handle NaN, etc.
-      context.LighthouseRunWarnings.push(runWarning.NoAds);
-      return auditNotApplicable.NoAds;
+      const naAuditProduct = auditNotApplicable.NoAds;
+      naAuditProduct.runWarnings = [runWarning.NoAds];
+      return naAuditProduct;
     }
 
     return {

--- a/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
@@ -97,6 +97,7 @@ class AdRequestFromPageStart extends Audit {
 
     return {
       numericValue: timing * 1e-3,
+      numericUnit: 'millisecond',
       score: Audit.computeLogNormalScore(
         {p10: scoreOptions.p10, median: scoreOptions.scoreMedian},
         timing

--- a/lighthouse-plugin-publisher-ads/audits/first-ad-render.js
+++ b/lighthouse-plugin-publisher-ads/audits/first-ad-render.js
@@ -104,8 +104,9 @@ class FirstAdRender extends Audit {
     const {timing} = await ComputedAdRenderTime.request(metricData, context);
 
     if (!(timing > 0)) { // Handle NaN, etc.
-      context.LighthouseRunWarnings.push(runWarning.NoAdRendered);
-      return auditNotApplicable.NoAdRendered;
+      const naAuditProduct = auditNotApplicable.NoAdRendered;
+      naAuditProduct.runWarnings = [runWarning.NoAdRendered];
+      return naAuditProduct;
     }
 
     let scoreOptions = context.options[

--- a/lighthouse-plugin-publisher-ads/audits/first-ad-render.js
+++ b/lighthouse-plugin-publisher-ads/audits/first-ad-render.js
@@ -121,6 +121,7 @@ class FirstAdRender extends Audit {
 
     return {
       numericValue: timing * 1e-3,
+      numericUnit: 'millisecond',
       score: Audit.computeLogNormalScore(
         {p10: scoreOptions.p10, median: scoreOptions.scoreMedian},
         timing

--- a/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
+++ b/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
@@ -90,8 +90,9 @@ class TagLoadTime extends Audit {
 
     const {timing} = await ComputedTagLoadTime.request(metricData, context);
     if (!(timing > 0)) { // Handle NaN, etc.
-      context.LighthouseRunWarnings.push(runWarning.NoTag);
-      return auditNotApplicable.NoTag;
+      const naAuditProduct = auditNotApplicable.NoTag;
+      naAuditProduct.runWarnings = [runWarning.NoTag];
+      return naAuditProduct;
     }
 
     // NOTE: score is relative to page response time to avoid counting time for

--- a/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
+++ b/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
@@ -99,6 +99,7 @@ class TagLoadTime extends Audit {
     // first party rendering.
     return {
       numericValue: timing * 1e-3, // seconds
+      numericUnit: 'millisecond', // TODO: seconds or ms ???????/
       score: Audit.computeLogNormalScore(
         {p10: scoreOptions.p10, median: scoreOptions.scoreMedian},
         timing

--- a/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
+++ b/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
@@ -98,8 +98,8 @@ class TagLoadTime extends Audit {
     // NOTE: score is relative to page response time to avoid counting time for
     // first party rendering.
     return {
-      numericValue: timing * 1e-3, // seconds
-      numericUnit: 'millisecond', // TODO: seconds or ms ???????/
+      numericValue: timing * 1e-3, // seconds => ms
+      numericUnit: 'millisecond',
       score: Audit.computeLogNormalScore(
         {p10: scoreOptions.p10, median: scoreOptions.scoreMedian},
         timing

--- a/lighthouse-plugin-publisher-ads/package.json
+++ b/lighthouse-plugin-publisher-ads/package.json
@@ -32,7 +32,7 @@
     "yargs": "^13.3.0"
   },
   "peerDependencies": {
-    "lighthouse": ">=5.6.0"
+    "lighthouse": ">=6.0.0-beta.0"
   },
   "devDependencies": {
     "@types/yargs": "^12.0.1",


### PR DESCRIPTION
we had a runWarnings change which also broke you. https://github.com/GoogleChrome/lighthouse/pull/10555

the numericUnit bit was to fix some typechecking. i _think_ it's right but didn't doublecheck. 