### PR TITLE
Measure ad-related layout shift

### DIFF
--- a/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
+++ b/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
@@ -1,3 +1,4 @@
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
+++ b/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
@@ -57,7 +57,7 @@ class CumulativeAdShift extends Audit {
     // TODO tune this
     return {
       p10: 0.05,
-      median: 0.2,
+      median: 0.25,
     };
   }
 

--- a/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
+++ b/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
@@ -18,7 +18,9 @@ const {isGptIframe} = require('../utils/resource-classification');
 const UIStrings = {
   title: 'Cumulative ad shift',
   failureTitle: 'Reduce ad-related layout shift',
-  description: 'TODO',
+  description: 'Measures [layout shifts](https://web.dev/cls) that were ' +
+    'caused by ads or happened near ads. Avoid layout shifts to improve ' +
+    'user experience.',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
@@ -66,7 +68,7 @@ class CumulativeAdShift extends Audit {
     // TODO tune this
     return {
       p10: 0.05,
-      median: 0.15,
+      median: 0.2,
     };
   }
 

--- a/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
+++ b/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
@@ -14,7 +14,7 @@
 const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
 const {Audit} = require('lighthouse');
 const {getScriptUrl} = require('../utils/network-timing');
-const {isGptIframe, isGptImplTag} = require('../utils/resource-classification');
+const {isAdIframe, isImplTag} = require('../utils/resource-classification');
 
 const UIStrings = {
   title: 'Cumulative ad shift',
@@ -111,20 +111,20 @@ class CumulativeAdShift extends Audit {
   static compute(traceEvents, iframes) {
     const shiftEvents = traceEvents.filter((e) => e.name === 'LayoutShift');
     const gptLoadEvent =
-        traceEvents.find((e) => isGptImplTag(getScriptUrl(e) || '')) ||
+        traceEvents.find((e) => isImplTag(getScriptUrl(e) || '')) ||
         {ts: Infinity};
     const gptLoadTs = gptLoadEvent.ts || Infinity;
 
     // Maybe we should look at the parent elements (created by the publisher and
     // passed to the ad tag) rather than the iframe itself.
-    const ads = iframes.filter(isGptIframe);
+    const ads = iframes.filter(isAdIframe);
 
     let cumulativeShift = 0;
     let numShifts = 0;
     let cumulativeAdShift = 0;
     let numAdShifts = 0;
-    let cumulativePreGptAdShift = 0;
-    let numPreGptAdShifts = 0;
+    let cumulativePreImplTagAdShift = 0;
+    let numPreImplTagAdShifts = 0;
     for (const event of shiftEvents) {
       if (!event.args || !event.args.data || !event.args.data.is_main_frame ||
           // @ts-ignore Sometimes the initial navigation counts as recent input.
@@ -140,8 +140,8 @@ class CumulativeAdShift extends Audit {
         numAdShifts++;
         if (event.ts < gptLoadTs) {
           // @ts-ignore
-          cumulativePreGptAdShift += event.args.data.score;
-          numPreGptAdShifts++;
+          cumulativePreImplTagAdShift += event.args.data.score;
+          numPreImplTagAdShifts++;
         }
       }
     }
@@ -150,8 +150,8 @@ class CumulativeAdShift extends Audit {
       numShifts,
       cumulativeAdShift,
       numAdShifts,
-      cumulativePreGptAdShift,
-      numPreGptAdShifts,
+      cumulativePreImplTagAdShift,
+      numPreImplTagAdShifts,
     };
   }
 

--- a/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
+++ b/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
@@ -126,7 +126,9 @@ class CumulativeAdShift extends Audit {
     let cumulativePreGptAdShift = 0;
     let numPreGptAdShifts = 0;
     for (const event of shiftEvents) {
-      if (!event.args || !event.args.data || !event.args.data.is_main_frame) {
+      if (!event.args || !event.args.data || !event.args.data.is_main_frame ||
+          // @ts-ignore Sometimes the initial navigation counts as recent input.
+          event.args.data.had_recent_input) {
         continue;
       }
       // @ts-ignore

--- a/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
+++ b/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
@@ -19,9 +19,10 @@ const {isGptIframe, isGptImplTag} = require('../utils/resource-classification');
 const UIStrings = {
   title: 'Cumulative ad shift',
   failureTitle: 'Reduce ad-related layout shift',
-  description: 'Measures [layout shifts](https://web.dev/cls) that were ' +
-    'caused by ads or happened near ads. Avoid layout shifts to improve ' +
-    'user experience.',
+  description:
+      'Measures [layout shifts](https://web.dev/cls) that were ' +
+          'caused by ads or happened near ads. Avoid layout shifts to improve ' +
+          'user experience.',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
@@ -64,7 +65,7 @@ class CumulativeAdShift extends Audit {
 
   /**
    * @return {LH.Audit.ScoreOptions}
-    */
+   */
   static get defaultOptions() {
     // TODO tune this
     return {
@@ -91,9 +92,9 @@ class CumulativeAdShift extends Audit {
         const adRect = ad.clientRect;
 
         const overlapX =
-          !(shift.right < adRect.left || adRect.right < shift.left);
+            !(shift.right < adRect.left || adRect.right < shift.left);
         const overlapY =
-          !(shift.bottom < adRect.top || adRect.bottom < shift.top);
+            !(shift.bottom < adRect.top || adRect.bottom < shift.top);
         if (overlapX && overlapY) {
           return true;
         }
@@ -108,11 +109,10 @@ class CumulativeAdShift extends Audit {
    * @param {Artifacts['IFrameElement'][]} iframes
    */
   static compute(traceEvents, iframes) {
-    const shiftEvents = traceEvents
-        .filter((e) => e.name === 'LayoutShift');
+    const shiftEvents = traceEvents.filter((e) => e.name === 'LayoutShift');
     const gptLoadEvent =
-      traceEvents.find((e) => isGptImplTag(getScriptUrl(e) || '')) ||
-      {ts: Infinity};
+        traceEvents.find((e) => isGptImplTag(getScriptUrl(e) || '')) ||
+        {ts: Infinity};
     const gptLoadTs = gptLoadEvent.ts || Infinity;
 
     // Maybe we should look at the parent elements (created by the publisher and

--- a/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
+++ b/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
@@ -1,0 +1,118 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
+const {auditNotApplicable} = require('../messages/common-strings');
+const {Audit} = require('lighthouse');
+const {isGptIframe} = require('../utils/resource-classification');
+
+const UIStrings = {
+  title: 'Cumulative ad shift',
+  failureTitle: 'Reduce ad-induced layout shift',
+  description: 'TODO',
+  displayValue: '{timeInMs, number} shifterinos',
+};
+
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+
+/**
+ * Audit to determine time for first ad request relative to page start.
+ */
+class CumulativeAdShift extends Audit {
+  /**
+   * @return {LH.Audit.Meta}
+   * @override
+   */
+  static get meta() {
+    return {
+      id: 'cumulative-ad-shift',
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
+      description: str_(UIStrings.description),
+      // @ts-ignore
+      scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
+      requiredArtifacts: ['devtoolsLogs', 'traces', 'IFrameElements'],
+    };
+  }
+
+  /**
+   * @return {{
+    *  simulate: LH.Audit.ScoreOptions, provided: LH.Audit.ScoreOptions
+    * }}
+    */
+  static get defaultOptions() {
+    // TODO tune this
+    return {
+      simulate: {
+        p10: 8900,
+        median: 15500,
+      },
+      provided: {
+        p10: 1900,
+        median: 3500,
+      },
+    };
+  }
+
+  static async compute(traceEvents, iframes) {
+    const shiftEvents = traceEvents
+      .filter(e => e.name === 'LayoutShift')
+      .map(e => e.args && e.args.data);;
+
+    const ads = iframes.filter(isGptFrame)
+
+    const adShifts = [];
+    for (const shiftEvent of shiftEvents) {
+      const [left, top, width, height] = shiftEvent.old_rect;
+
+      for (const ad of ads) {
+        const overlapX = Math.max(left, iframe.left) > Math.min(x + width, iframe.right);
+        const overlapY = Math.max(top, iframe.top) > Math.min(top + height, iframe.bottom);
+        if (overlapX && overlapY) {
+          adShifts.push(shiftEvent);
+          continue;
+        }
+      }
+    }
+    for (const shift of adShifts) {
+      console.log(shift);
+    }
+  }
+
+  /**
+   * @param {LH.Artifacts} artifacts
+   * @param {LH.Audit.Context} context
+   * @return {Promise<LH.Audit.Product>}
+   */
+  static async audit(artifacts, context) {
+    const trace = artifacts.traces[Audit.DEFAULT_PASS];
+    const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
+    const metricData = {trace, devtoolsLog, settings: context.settings};
+    console.log(trace);
+    this.compute(trace.traceEvents, artifacts.IframeElements);
+
+    return {
+      numericValue: timing * 1e-3,
+      numericUnit: 'millisecond',
+      score: Audit.computeLogNormalScore(
+        scoreOptions,
+        timing
+      ),
+      displayValue: str_(UIStrings.displayValue, {timeInMs: timing}),
+    };
+  }
+}
+
+module.exports = CumulativeAdShift;
+module.exports.UIStrings = UIStrings;

--- a/lighthouse-plugin-publisher-ads/messages/common-strings.js
+++ b/lighthouse-plugin-publisher-ads/messages/common-strings.js
@@ -32,6 +32,7 @@ const UIStrings = {
   NOT_APPLICABLE__NO_TAGS: 'No tags requested',
   NOT_APPLICABLE__NO_TASKS: 'No tasks to compare',
   NOT_APPLICABLE__NO_VALID_AD_WIDTHS: 'No requested ads contain ads of valid width',
+  NOT_APPLICABLE__NO_LAYOUT_SHIFTS: 'No layout shift events found',
 
   ERRORS__AREA_LARGER_THAN_VIEWPORT: 'Calculated ad area is larger than viewport',
   ERRORS__VIEWPORT_AREA_ZERO: 'Viewport area is zero',
@@ -70,6 +71,7 @@ const auditNotApplicable = {
   NoEventMatchingReq: notApplicableObj(
     UIStrings.NOT_APPLICABLE__NO_EVENT_MATCHING_REQ),
   NoGpt: notApplicableObj(UIStrings.NOT_APPLICABLE__NO_GPT),
+  NoLayoutShifts: notApplicableObj(UIStrings.NOT_APPLICABLE__NO_LAYOUT_SHIFTS),
   NoRecords: notApplicableObj(UIStrings.NOT_APPLICABLE__NO_RECORDS),
   NoVisibleSlots: notApplicableObj(UIStrings.NOT_APPLICABLE__NO_VISIBLE_SLOTS),
   NoTag: notApplicableObj(UIStrings.NOT_APPLICABLE__NO_TAG),

--- a/lighthouse-plugin-publisher-ads/plugin.js
+++ b/lighthouse-plugin-publisher-ads/plugin.js
@@ -68,7 +68,7 @@ module.exports = {
       {id: 'bid-request-from-page-start', weight: 4, group: 'metrics'},
       {id: 'ad-request-from-page-start', weight: 20, group: 'metrics'},
       {id: 'first-ad-render', weight: 10, group: 'metrics'},
-      {id: 'cumulative-ad-shift', weight: 10, group: 'metrics'},
+      {id: 'cumulative-ad-shift', weight: 0, group: 'metrics'},
       // Performance group.
       {id: 'gpt-bids-parallel', weight: 1, group: 'ads-performance'},
       {id: 'serial-header-bidding', weight: 1, group: 'ads-performance'},

--- a/lighthouse-plugin-publisher-ads/plugin.js
+++ b/lighthouse-plugin-publisher-ads/plugin.js
@@ -46,6 +46,7 @@ module.exports = {
     {path: `${PLUGIN_PATH}/audits/serial-header-bidding`},
     {path: `${PLUGIN_PATH}/audits/tag-load-time`},
     {path: `${PLUGIN_PATH}/audits/viewport-ad-density`},
+    {path: `${PLUGIN_PATH}/audits/cumulative-ad-shift`},
   ],
   groups: {
     'metrics': {
@@ -67,6 +68,7 @@ module.exports = {
       {id: 'bid-request-from-page-start', weight: 4, group: 'metrics'},
       {id: 'ad-request-from-page-start', weight: 20, group: 'metrics'},
       {id: 'first-ad-render', weight: 10, group: 'metrics'},
+      {id: 'cumulative-ad-shift', weight: 10, group: 'metrics'},
       // Performance group.
       {id: 'gpt-bids-parallel', weight: 1, group: 'ads-performance'},
       {id: 'serial-header-bidding', weight: 1, group: 'ads-performance'},

--- a/lighthouse-plugin-publisher-ads/plugin.js
+++ b/lighthouse-plugin-publisher-ads/plugin.js
@@ -64,11 +64,11 @@ module.exports = {
     description: str_(UIStrings.categoryDescription),
     auditRefs: [
       // Measurements group.
-      {id: 'tag-load-time', weight: 4, group: 'metrics'},
-      {id: 'bid-request-from-page-start', weight: 4, group: 'metrics'},
-      {id: 'ad-request-from-page-start', weight: 20, group: 'metrics'},
+      {id: 'tag-load-time', weight: 5, group: 'metrics'},
+      {id: 'bid-request-from-page-start', weight: 5, group: 'metrics'},
+      {id: 'ad-request-from-page-start', weight: 25, group: 'metrics'},
       {id: 'first-ad-render', weight: 10, group: 'metrics'},
-      {id: 'cumulative-ad-shift', weight: 0, group: 'metrics'},
+      {id: 'cumulative-ad-shift', weight: 5, group: 'metrics'},
       // Performance group.
       {id: 'gpt-bids-parallel', weight: 1, group: 'ads-performance'},
       {id: 'serial-header-bidding', weight: 1, group: 'ads-performance'},

--- a/lighthouse-plugin-publisher-ads/test/utils/geometry_test.js
+++ b/lighthouse-plugin-publisher-ads/test/utils/geometry_test.js
@@ -170,4 +170,66 @@ describe('geometry', () => {
       expect(geometry.toClientRect(points)).to.deep.equal(expectedRect);
     });
   });
+
+  describe('overlaps', () => {
+    it('should pass on nested rectangles', () => {
+      const inner =
+        {top: 20, bottom: 40, height: 20, left: 20, right: 40, width: 20};
+      const outer =
+        {top: 0, bottom: 100, height: 100, left: 0, right: 100, width: 20};
+      expect(geometry.overlaps(inner, outer)).to.equal(true);
+      expect(geometry.overlaps(outer, inner)).to.equal(true);
+    });
+
+    it('should pass on equal rectangles', () => {
+      const rect =
+        {top: 20, bottom: 40, height: 20, left: 20, right: 40, width: 20};
+      expect(geometry.overlaps(rect, rect)).to.equal(true);
+    });
+
+    it('should pass on rectangles with overlapping horizontal edge', () => {
+      const top =
+        {top: 20, bottom: 40, height: 20, left: 20, right: 40, width: 20};
+      const bottom =
+        {top: 40, bottom: 60, height: 20, left: 30, right: 35, width: 5};
+      expect(geometry.overlaps(top, bottom)).to.equal(true);
+      expect(geometry.overlaps(bottom, top)).to.equal(true);
+    });
+
+    it('should pass on rectangles with overlapping vertical edge', () => {
+      const left =
+        {top: 30, bottom: 35, height: 5, left: 0, right: 20, width: 20};
+      const right =
+        {top: 20, bottom: 40, height: 20, left: 20, right: 40, width: 20};
+      expect(geometry.overlaps(left, right)).to.equal(true);
+      expect(geometry.overlaps(right, left)).to.equal(true);
+    });
+
+    it('should pass when overlaps', () => {
+      const a =
+        {top: 20, bottom: 40, height: 20, left: 20, right: 40, width: 20};
+      const b =
+        {top: 30, bottom: 50, height: 20, left: 30, right: 50, width: 20};
+      expect(geometry.overlaps(a, b)).to.equal(true);
+      expect(geometry.overlaps(a, b)).to.equal(true);
+    });
+
+    it('should fail on mismatching horizontal dimensions', () => {
+      const top =
+        {top: 20, bottom: 40, height: 20, left: 20, right: 40, width: 20};
+      const bottom =
+        {top: 50, bottom: 70, height: 20, left: 30, right: 35, width: 5};
+      expect(geometry.overlaps(top, bottom)).to.equal(false);
+      expect(geometry.overlaps(bottom, top)).to.equal(false);
+    });
+
+    it('should fail on mismatching vertical dimensions', () => {
+      const left =
+        {top: 30, bottom: 35, height: 5, left: 0, right: 20, width: 20};
+      const right =
+        {top: 20, bottom: 40, height: 20, left: 30, right: 50, width: 20};
+      expect(geometry.overlaps(left, right)).to.equal(false);
+      expect(geometry.overlaps(right, left)).to.equal(false);
+    });
+  });
 });

--- a/lighthouse-plugin-publisher-ads/test/utils/geometry_test.js
+++ b/lighthouse-plugin-publisher-ads/test/utils/geometry_test.js
@@ -155,4 +155,19 @@ describe('geometry', () => {
       });
     });
   });
+
+  describe('toClientRect', () => {
+    it('should build a correct rect', () => {
+      const points = [100, 1000, 300, 250];
+      const expectedRect = {
+        left: 100,
+        right: 400,
+        top: 1000,
+        bottom: 1250,
+        width: 300,
+        height: 250,
+      };
+      expect(geometry.toClientRect(points)).to.deep.equal(expectedRect);
+    });
+  });
 });

--- a/lighthouse-plugin-publisher-ads/utils/geometry.js
+++ b/lighthouse-plugin-publisher-ads/utils/geometry.js
@@ -45,14 +45,14 @@ function boxViewableArea(clientRect, viewport) {
  * @param {number[]} points
  * @return {ClientRect}
  */
-function toClientRect(points) {
+function toClientRect([left, top, width, height]) {
   return {
-    left: points[0],
-    top: points[1],
-    width: points[2],
-    height: points[3],
-    right: points[0] + points[2],
-    bottom: points[1] + points[3],
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
   };
 }
 

--- a/lighthouse-plugin-publisher-ads/utils/geometry.js
+++ b/lighthouse-plugin-publisher-ads/utils/geometry.js
@@ -40,8 +40,39 @@ function boxViewableArea(clientRect, viewport) {
     (Math.min(bottom, innerHeight) - Math.max(top, 0));
 }
 
+/**
+ * Converts points (from a TraceEvent) to a ClientRect.
+ * @param {number[]} points
+ * @return {ClientRect}
+ */
+function toClientRect(points) {
+  return {
+    left: points[0],
+    top: points[1],
+    width: points[2],
+    height: points[3],
+    right: points[0] + points[2],
+    bottom: points[1] + points[3],
+  };
+}
+
+/**
+ * Checks ClientRect a overlaps ClientRect b. Note that this returns true for
+ * overlapping perimeters.
+ * @param {ClientRect} a
+ * @param {ClientRect} b
+ * @return {boolean}
+ */
+function overlaps(a, b) {
+  const overlapX = !(a.right < b.left || b.right < a.left);
+  const overlapY = !(a.bottom < b.top || b.bottom < a.top);
+  return overlapX && overlapY;
+}
+
 module.exports = {
-  isBoxInViewport,
   boxViewableArea,
+  isBoxInViewport,
+  overlaps,
+  toClientRect,
 };
 

--- a/lighthouse-plugin-publisher-ads/utils/network-timing.js
+++ b/lighthouse-plugin-publisher-ads/utils/network-timing.js
@@ -212,6 +212,7 @@ module.exports = {
   getBidStartTime,
   getPageStartTime,
   getPageResponseTime,
+  getScriptUrl,
   getTimingsByRecord,
   getScriptEvaluationTimes,
 };

--- a/lighthouse-plugin-publisher-ads/utils/resource-classification.js
+++ b/lighthouse-plugin-publisher-ads/utils/resource-classification.js
@@ -217,7 +217,7 @@ function isAdIframe(iframe) {
 
 /**
  * Checks if the url is loading either the AdSense or GPT impl script.
- * @param {URL} url
+ * @param {URL|string} url
  * @return {boolean}
  */
 function isImplTag(url) {


### PR DESCRIPTION
Measures ad-related layout shift by summing scores across layout shifts where the `old_rect` was later occupied by an ad.

Some possible TODOs for follow-up PRs

- Tune scores
- Weigh the metric
- Write docs
- Audit Smoke Tests
- Audit for best practices
- Consider other metrics (# of ad related layout shifts or % of CLS attributable to ads in some way)
- The metric currently only checks the ad's iframe when counting ad shifts, but we may want to consider the ad's parent or grandparent element to handle padding, etc.

Feedback would be appreciated