### PR TITLE
Ignore ad scripts in bottleneck request audit.

### DIFF
--- a/lighthouse-plugin-publisher-ads/audits/bottleneck-requests.js
+++ b/lighthouse-plugin-publisher-ads/audits/bottleneck-requests.js
@@ -16,6 +16,7 @@ const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {computeAdRequestWaterfall} = require('../utils/graph');
+const {isAdScript, toURL} =  require('../utils/resource-classification')
 
 /** @typedef {LH.Artifacts.NetworkRequest} NetworkRequest */
 /** @typedef {import('../utils/graph').SimpleRequest} SimpleRequest */
@@ -101,7 +102,8 @@ class BottleneckRequests extends Audit {
     const CRITICAL_DURATION_MS = 1000;
     /** @param {SimpleRequest} r @return {boolean} */
     const isBottleneck = (r) =>
-      r.selfTime > CRITICAL_SELF_TIME_MS || r.duration > CRITICAL_DURATION_MS;
+      !isAdScript(toURL(r.url)) &&
+      (r.selfTime > CRITICAL_SELF_TIME_MS || r.duration > CRITICAL_DURATION_MS);
     // selfTime is more costly than duration so weigh it more than duration.
     /** @param {SimpleRequest} r @return {number} */
     const cost = (r) => r.selfTime * 3 + r.duration;

--- a/lighthouse-plugin-publisher-ads/audits/bottleneck-requests.js
+++ b/lighthouse-plugin-publisher-ads/audits/bottleneck-requests.js
@@ -16,7 +16,7 @@ const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {computeAdRequestWaterfall} = require('../utils/graph');
-const {isAdScript, toURL} =  require('../utils/resource-classification')
+const {isAdScript, toURL} = require('../utils/resource-classification');
 
 /** @typedef {LH.Artifacts.NetworkRequest} NetworkRequest */
 /** @typedef {import('../utils/graph').SimpleRequest} SimpleRequest */

--- a/lighthouse-plugin-publisher-ads/lighthouse-plugin-publisher-ads
+++ b/lighthouse-plugin-publisher-ads/lighthouse-plugin-publisher-ads
@@ -1,0 +1,1 @@
+../../lighthouse-plugin-publisher-ads

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/script-injected.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/script-injected.js
@@ -51,15 +51,9 @@ module.exports = [
           },
         },
         'bottleneck-requests': {
-          score: 0,
+          score: 1,
           details: {
-            items: [
-              {
-                url: new RegExp(
-                  /(.*\/gpt\/pubads_impl([a-z_]*)((?<!rendering)_)\d+\.js)/, 'g'),
-              },
-              {url: 'https://securepubads.g.doubleclick.net/tag/js/gpt.js'},
-            ],
+            items: [],
           },
         },
       },

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/script-injected.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/script-injected.js
@@ -50,6 +50,7 @@ module.exports = [
             ],
           },
         },
+        // TODO(jburger): Update test to include useful coverage for this audit.
         'bottleneck-requests': {
           score: 1,
           details: {


### PR DESCRIPTION
As the loading of ad scripts is required to load ads, they should not be considered a bottleneck.