### PR TITLE
Stop converting time-based numericValues to seconds.

### DIFF
--- a/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
@@ -91,7 +91,7 @@ class AdRequestFromPageStart extends Audit {
     }
 
     return {
-      numericValue: timing * 1e-3,
+      numericValue: timing,
       numericUnit: 'millisecond',
       score: Audit.computeLogNormalScore(
         scoreOptions,

--- a/lighthouse-plugin-publisher-ads/audits/bid-request-from-page-start.js
+++ b/lighthouse-plugin-publisher-ads/audits/bid-request-from-page-start.js
@@ -90,7 +90,7 @@ class BidRequestFromPageStart extends Audit {
     }
 
     return {
-      numericValue: timing * 1e-3,
+      numericValue: timing,
       numericUnit: 'millisecond',
       score: Audit.computeLogNormalScore(
         scoreOptions,

--- a/lighthouse-plugin-publisher-ads/audits/first-ad-render.js
+++ b/lighthouse-plugin-publisher-ads/audits/first-ad-render.js
@@ -98,7 +98,7 @@ class FirstAdRender extends Audit {
     ];
 
     return {
-      numericValue: timing * 1e-3,
+      numericValue: timing,
       numericUnit: 'millisecond',
       score: Audit.computeLogNormalScore(
         scoreOptions,

--- a/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
+++ b/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
@@ -93,7 +93,7 @@ class TagLoadTime extends Audit {
     // NOTE: score is relative to page response time to avoid counting time for
     // first party rendering.
     return {
-      numericValue: timing * 1e-3, // seconds => ms
+      numericValue: timing,
       numericUnit: 'millisecond',
       score: Audit.computeLogNormalScore(
         scoreOptions,

--- a/lighthouse-plugin-publisher-ads/lighthouse-plugin-publisher-ads
+++ b/lighthouse-plugin-publisher-ads/lighthouse-plugin-publisher-ads
@@ -1,0 +1,1 @@
+../../lighthouse-plugin-publisher-ads

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/long-tasks.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/long-tasks.js
@@ -23,11 +23,11 @@ module.exports = [
       finalUrl: 'http://localhost:8081/long-tasks.html',
       audits: {
         'tag-load-time': {
-          numericValue: '3.25 +/- 1',
+          numericValue: '3250 +/- 1000',
         },
         'first-ad-render': {
           // TODO(jburger): Update when https://github.com/GoogleChrome/lighthouse/issues/9417 is implemented.
-          numericValue: '5.5 +/- 1',
+          numericValue: '5500 +/- 1000',
         },
         'loads-gpt-from-sgdn': {
           score: 0,


### PR DESCRIPTION
This resolves https://github.com/googleads/publisher-ads-lighthouse-plugin/issues/213.