### PR TITLE
Delete unused symlink.

### DIFF
--- a/lighthouse-plugin-publisher-ads/lighthouse-plugin-publisher-ads
+++ b/lighthouse-plugin-publisher-ads/lighthouse-plugin-publisher-ads
@@ -1,1 +1,0 @@
-../../lighthouse-plugin-publisher-ads


### PR DESCRIPTION
This accidentally made it into https://github.com/googleads/publisher-ads-lighthouse-plugin/pull/216.