### PR TITLE
Add templates for bugs and FRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -13,5 +13,6 @@ Include the following information
 - What is the actual behavior
 - Steps to reproduce
   - Environment (CLI or web service)
+  - Version
   - Site
   - Settings

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -14,5 +14,5 @@ Include the following information
 - Steps to reproduce
   - Environment (CLI or web service)
   - Version
-  - Site
+  - URL
   - Settings

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,17 @@
+---
+name: Bug
+about: Report a bug or confusing behavior
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+Include the following information
+
+- What is the expected behavior
+- What is the actual behavior
+- Steps to reproduce
+  - Environment (CLI or web service)
+  - Site
+  - Settings

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,10 @@
+---
+name: Feature Request
+about: Provide a feature request
+title: Feature Request: ...
+labels: feature-request
+assignees: ''
+
+---
+
+Describe your feature request.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
 about: Provide a feature request
-title: Feature Request: ...
+title: ''
 labels: feature-request
 assignees: ''
 


### PR DESCRIPTION
Add templates for filing bugs and FRs. We have one template so the flow for filing a new issue shows two options: doc feedback and blank issue, but the link for filing a blank issue is not obvious.