### PR TITLE
Show name + URL instead of abbreviated URLs in reports

### DIFF
--- a/lighthouse-plugin-publisher-ads/audits/ad-request-critical-path.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-critical-path.js
@@ -44,14 +44,14 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
  */
 const HEADINGS = [
   {
+    key: 'nameOrTld',
+    itemType: 'text',
+    text: str_(UIStrings.columnType),
+  },
+  {
     key: 'url',
     itemType: 'url',
     text: str_(UIStrings.columnUrl),
-  },
-  {
-    key: 'type',
-    itemType: 'text',
-    text: str_(UIStrings.columnType),
   },
   {
     key: 'startTime',

--- a/lighthouse-plugin-publisher-ads/audits/gpt-bids-parallel.js
+++ b/lighthouse-plugin-publisher-ads/audits/gpt-bids-parallel.js
@@ -18,7 +18,7 @@ const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {getCriticalGraph} = require('../utils/graph');
 const {getTimingsByRecord} = require('../utils/network-timing');
-const {isGptImplTag, isBidRequest, getAbbreviatedUrl, getHeaderBidder} = require('../utils/resource-classification');
+const {isGptImplTag, isBidRequest, getHeaderBidder} = require('../utils/resource-classification');
 
 /** @typedef {LH.Artifacts.NetworkRequest} NetworkRequest */
 /** @typedef {LH.Gatherer.Simulation.NodeTiming} NodeTiming */
@@ -106,7 +106,7 @@ class GptBidsInParallel extends Audit {
         seen.add(bidder);
         tableView.push({
           bidder,
-          url: getAbbreviatedUrl(bid.url),
+          url: bid.url,
           startTime,
           duration: endTime - startTime,
         });

--- a/lighthouse-plugin-publisher-ads/audits/serial-header-bidding.js
+++ b/lighthouse-plugin-publisher-ads/audits/serial-header-bidding.js
@@ -22,7 +22,7 @@ const {Audit} = require('lighthouse');
 const {bucket} = require('../utils/array');
 const {getTimingsByRecord} = require('../utils/network-timing');
 const {isCacheable} = require('../utils/network');
-const {isGoogleAds, getHeaderBidder, getAbbreviatedUrl} = require('../utils/resource-classification');
+const {isGoogleAds, getHeaderBidder} = require('../utils/resource-classification');
 const {URL} = require('url');
 
 /** @typedef {LH.Artifacts.NetworkRequest} NetworkRequest */
@@ -91,7 +91,7 @@ function constructRecords(records, recordType, timings) {
     const timing = timings.get(record);
     if (!timing) continue;
     results.push(Object.assign({}, timing, {
-      url: getAbbreviatedUrl(record.url),
+      url: record.url,
       type: recordType,
     }));
   }

--- a/lighthouse-plugin-publisher-ads/tsconfig.json
+++ b/lighthouse-plugin-publisher-ads/tsconfig.json
@@ -21,7 +21,8 @@
     "../node_modules/lighthouse/lighthouse-core/report/html/renderer/i18n.js",
     "../node_modules/lighthouse/lighthouse-core/lib/network-request.js",
     "../node_modules/lighthouse/lighthouse-core/lib/url-shim.js",
-    "../node_modules/lighthouse/lighthouse-core/lib/dependency-graph/*.js"
+    "../node_modules/lighthouse/lighthouse-core/lib/dependency-graph/*.js",
+    "../node_modules/lighthouse/lighthouse-core/lib/third-party-web.js"
   ],
   "exclude": [
     "test/**/*.js",

--- a/lighthouse-plugin-publisher-ads/utils/bidder-patterns.js
+++ b/lighthouse-plugin-publisher-ads/utils/bidder-patterns.js
@@ -33,7 +33,7 @@ module.exports = [
     ],
   },
   {
-    label: 'Amazon',
+    label: 'Amazon Ads',
     patterns: [
       '^https?://[a-z-_.]*[.]amazon-adsystem[.]com/.*bid.*',
     ],


### PR DESCRIPTION
Closes #212 

Also updates the critical path audit to show party alongside URL.
![Screen Shot 2020-10-23 at 1 38 31 PM](https://user-images.githubusercontent.com/5326842/97035944-11bd4a00-1535-11eb-876a-501955b9ac0f.png)
