### PR TITLE
Measure ad density vertically

### DIFF
--- a/docs/audits/viewport-ad-density.md
+++ b/docs/audits/viewport-ad-density.md
@@ -15,6 +15,12 @@ a reduced size.
 
 ## More information
 
+On mobile devices, we assume a single column layout and so all ads on the page
+are included in the ad density calculation. On desktop, we divide the page into
+multiple vertical slices to account for multi-column layouts. The audit measures
+ad density in each slice individually to ensure no individual slice exceeds the
+maximum recommended threshold.
+
 [Ad Experience: Ad Density Higher Than 30%](https://www.betterads.org/mobile-ad-density-higher-than-30/)  
 [What publishers need to know now about creating a better ad experience](https://www.thinkwithgoogle.com/marketing-resources/better-ad-standards/)
 

--- a/docs/audits/viewport-ad-density.md
+++ b/docs/audits/viewport-ad-density.md
@@ -2,11 +2,9 @@
 
 ## Overview
 
-This audit ensures that ads take up no more than 30% of the page vertically. On
-mobile, we check the density of all ads on the page together. On desktop we
-measure ad density on each column separately and check that no column exceeds
-the recommended threshold. An ad density greater than 30% has been found to
-negatively impact user experience[^1].
+This audit ensures that ads take up no more than 30% of the page vertically. An
+ad density greater than 30% has been found to negatively impact user
+experience[^1].
 
 ## Recommendations
 
@@ -20,6 +18,9 @@ are included in the ad density calculation. On desktop, we divide the page into
 multiple vertical slices to account for multi-column layouts. The audit measures
 ad density in each slice individually to ensure no individual slice exceeds the
 maximum recommended threshold.
+
+To account for lazy loading, we measure content length up to 1 viewport past the
+last ad. To measure ad density over the entire content, disable lazy loading.
 
 [Ad Experience: Ad Density Higher Than 30%](https://www.betterads.org/mobile-ad-density-higher-than-30/)  
 [What publishers need to know now about creating a better ad experience](https://www.thinkwithgoogle.com/marketing-resources/better-ad-standards/)

--- a/docs/audits/viewport-ad-density.md
+++ b/docs/audits/viewport-ad-density.md
@@ -1,10 +1,12 @@
-# Reduce ad density in initial viewport
+# Reduce ad density
 
 ## Overview
 
-This audit ensures that visible ads take up no more than 30% of the initial
-viewport. An ad density greater than this has been found to negatively impact
-user experience[^1].
+This audit ensures that ads take up no more than 30% of the page vertically. On
+mobile, we check the density of all ads on the page together. On desktop we
+measure ad density on each column separately and check that no column exceeds
+the recommended threshold. An ad density greater than 30% has been found to
+negatively impact user experience[^1].
 
 ## Recommendations
 

--- a/lighthouse-plugin-publisher-ads/audits/viewport-ad-density.js
+++ b/lighthouse-plugin-publisher-ads/audits/viewport-ad-density.js
@@ -120,6 +120,8 @@ class ViewportAdDensity extends Audit {
     // by lazy loading.
     const adsBottom =
       Math.max(...slots.map((s) => s.clientRect.top + s.clientRect.height / 2));
+    // TODO(warrengm): Implement a DocumentDimensions gatherer to ensure that
+    // we don't exceed the footer.
     const documentLength = adsBottom + viewport.innerHeight;
 
     const adDensity = Math.min(1, adsLength / documentLength);

--- a/lighthouse-plugin-publisher-ads/audits/viewport-ad-density.js
+++ b/lighthouse-plugin-publisher-ads/audits/viewport-ad-density.js
@@ -15,14 +15,13 @@
 const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
 const {auditNotApplicable, auditError} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
-const {boxViewableArea} = require('../utils/geometry');
 const {isAdIframe} = require('../utils/resource-classification');
 
 const UIStrings = {
-  title: 'Ad density in the document is within recommended range',
-  failureTitle: 'Reduce ad density in the document',
-  description: 'The ads-to-content ratio inside the document can have an ' +
-  'impact on user experience and ultimately user retention. The Better Ads ' +
+  title: 'Ad density is within recommended range',
+  failureTitle: 'Reduce ad density',
+  description: 'Ad density, the ads-to-content ratio, can impact user ' +
+  'experience and ultimately user retention. The Better Ads ' +
   'Standard [recommends having an ad density below 30%]' +
   '(https://www.betterads.org/mobile-ad-density-higher-than-30/). ' +
   '[Learn more](' +
@@ -71,11 +70,11 @@ class ViewportAdDensity extends Audit {
     // We measure document length based on the bottom ad so that it isn't skewed
     // by lazy loading.
     const adsBottom =
-      Math.max(...slots.map(s => s.clientRect.top + s.clientRect.height / 2));
+      Math.max(...slots.map((s) => s.clientRect.top + s.clientRect.height / 2));
     const documentLength = adsBottom + viewport.innerHeight;
 
     const adHeights =
-      slots.map(s => s.clientRect.height).reduce((a, b) => a + b, 0);
+      slots.map((s) => s.clientRect.height).reduce((a, b) => a + b, 0);
 
     const adDensity = adHeights / documentLength;
     const score = adDensity > 0.3 ? 0 : 1;

--- a/lighthouse-plugin-publisher-ads/audits/viewport-ad-density.js
+++ b/lighthouse-plugin-publisher-ads/audits/viewport-ad-density.js
@@ -19,16 +19,16 @@ const {boxViewableArea} = require('../utils/geometry');
 const {isAdIframe} = require('../utils/resource-classification');
 
 const UIStrings = {
-  title: 'Ad density in initial viewport is within recommended range',
-  failureTitle: 'Reduce ad density in initial viewport',
-  description: 'The ads-to-content ratio inside the viewport can have an ' +
+  title: 'Ad density in the document is within recommended range',
+  failureTitle: 'Reduce ad density in the document',
+  description: 'The ads-to-content ratio inside the document can have an ' +
   'impact on user experience and ultimately user retention. The Better Ads ' +
   'Standard [recommends having an ad density below 30%]' +
   '(https://www.betterads.org/mobile-ad-density-higher-than-30/). ' +
   '[Learn more](' +
   'https://developers.google.com/publisher-ads-audits/reference/audits/viewport-ad-density' +
   ').',
-  displayValue: '{adDensity, number, percent} covered by ads',
+  displayValue: '{adDensity, number, percent} ad density',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
@@ -64,22 +64,24 @@ class ViewportAdDensity extends Audit {
       return auditNotApplicable.NoVisibleSlots;
     }
 
-    const adArea = slots.reduce((sum, slot) =>
-      sum + boxViewableArea(slot.clientRect, viewport), 0);
-
-    const viewArea = viewport.innerWidth * viewport.innerHeight;
-
-    if (viewArea <= 0) {
+    if (viewport.innerHeight <= 0) {
       throw new Error(auditError.ViewportAreaZero);
     }
-    if (adArea > viewArea) {
-      throw new Error(auditError.AreaLargerThanViewport);
-    }
-    const adDensity = adArea / viewArea;
+
+    // We measure document length based on the bottom ad so that it isn't skewed
+    // by lazy loading.
+    const adsBottom =
+      Math.max(...slots.map(s => s.clientRect.top + s.clientRect.height / 2));
+    const documentLength = adsBottom + viewport.innerHeight;
+
+    const adHeights =
+      slots.map(s => s.clientRect.height).reduce((a, b) => a + b, 0);
+
+    const adDensity = adHeights / documentLength;
     const score = adDensity > 0.3 ? 0 : 1;
     return {
       score,
-      numericValue: adArea / viewArea,
+      numericValue: adDensity,
       numericUnit: 'unitless',
       displayValue: str_(UIStrings.displayValue, {adDensity}),
     };

--- a/lighthouse-plugin-publisher-ads/audits/viewport-ad-density.js
+++ b/lighthouse-plugin-publisher-ads/audits/viewport-ad-density.js
@@ -35,7 +35,7 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 /**
  * @param {LH.Artifacts.IFrameElement[]} slots
  * @param {LH.Artifacts.ViewportDimensions} viewport
- * @return {number
+ * @return {number}
  */
 function computeAdLength(slots, viewport) {
   // We compute ad density along the vertical axis per the spec. On mobile
@@ -44,10 +44,10 @@ function computeAdLength(slots, viewport) {
   // return the greatest sum of ad heights along one of those lines.
 
   /** @type {Set<number>} */
-  const scanLines = new Set(slots.flatMap((s) => [
-    s.clientRect.left,
-    s.clientRect.right,
-  ]).map((x) => Math.min(Math.max(1, x), viewport.innerWidth - 1)));
+  const scanLines = new Set([
+    ...slots.map((s) => s.clientRect.left),
+    ...slots.map((s) => s.clientRect.right),
+  ].map((x) => Math.min(Math.max(1, x), viewport.innerWidth - 1)));
 
   slots = slots.sort((a, b) => a.clientRect.top !== b.clientRect.top ?
     a.clientRect.top - b.clientRect.top :

--- a/lighthouse-plugin-publisher-ads/messages/common-strings.js
+++ b/lighthouse-plugin-publisher-ads/messages/common-strings.js
@@ -88,7 +88,6 @@ const runWarning = {
 };
 
 const auditError = {
-  AreaLargerThanViewport: str_(UIStrings.ERRORS__AREA_LARGER_THAN_VIEWPORT),
   ViewportAreaZero: str_(UIStrings.ERRORS__VIEWPORT_AREA_ZERO),
 };
 

--- a/lighthouse-plugin-publisher-ads/messages/en-US.json
+++ b/lighthouse-plugin-publisher-ads/messages/en-US.json
@@ -508,19 +508,19 @@
     "description": ""
   },
   "audits/viewport-ad-density.js | description": {
-    "message": "The ads-to-content ratio inside the viewport can have an impact on user experience and ultimately user retention. The Better Ads Standard [recommends having an ad density below 30%](https://www.betterads.org/mobile-ad-density-higher-than-30/). [Learn more](https://developers.google.com/publisher-ads-audits/reference/audits/viewport-ad-density).",
+    "message": "Ad density, the ads-to-content ratio, can impact user experience and ultimately user retention. The Better Ads Standard [recommends having an ad density below 30%](https://www.betterads.org/mobile-ad-density-higher-than-30/). [Learn more](https://developers.google.com/publisher-ads-audits/reference/audits/viewport-ad-density).",
     "description": ""
   },
   "audits/viewport-ad-density.js | displayValue": {
-    "message": "{adDensity, number, percent} covered by ads",
+    "message": "{adDensity, number, percent} ad density",
     "description": ""
   },
   "audits/viewport-ad-density.js | failureTitle": {
-    "message": "Reduce ad density in initial viewport",
+    "message": "Reduce ad density",
     "description": ""
   },
   "audits/viewport-ad-density.js | title": {
-    "message": "Ad density in initial viewport is within recommended range",
+    "message": "Ad density is within recommended range",
     "description": ""
   },
   "messages/common-strings.js | ERRORS__AREA_LARGER_THAN_VIEWPORT": {

--- a/lighthouse-plugin-publisher-ads/messages/locales/en-XL.json
+++ b/lighthouse-plugin-publisher-ads/messages/locales/en-XL.json
@@ -381,16 +381,16 @@
     "message": "T̂áĝ ĺôád̂ t́îḿê"
   },
   "audits/viewport-ad-density.js | description": {
-    "message": "T̂h́ê ád̂ś-t̂ó-ĉón̂t́êńt̂ ŕât́îó îńŝíd̂é t̂h́ê v́îéŵṕôŕt̂ ćâń ĥáv̂é âń îḿp̂áĉt́ ôń ûśêŕ êx́p̂ér̂íêńĉé âńd̂ úl̂t́îḿât́êĺŷ úŝér̂ ŕêt́êńt̂íôń. T̂h́ê B́êt́t̂ér̂ Ád̂ś Ŝt́âńd̂ár̂d́ [r̂éĉóm̂ḿêńd̂ś ĥáv̂ín̂ǵ âń âd́ d̂én̂śît́ŷ b́êĺôẃ 30%](ĥt́t̂ṕŝ://ẃŵẃ.b̂ét̂t́êŕâd́ŝ.ór̂ǵ/m̂ób̂íl̂é-âd́-d̂én̂śît́ŷ-h́îǵĥér̂-t́ĥán̂-30/). [Ĺêár̂ń m̂ór̂é](ĥt́t̂ṕŝ://d́êv́êĺôṕêŕŝ.ǵôóĝĺê.ćôḿ/p̂úb̂ĺîśĥér̂-ád̂ś-âúd̂ít̂ś/r̂éf̂ér̂én̂ćê/áûd́ît́ŝ/v́îéŵṕôŕt̂-ád̂-d́êńŝít̂ý)."
+    "message": "Âd́ d̂én̂śît́ŷ, t́ĥé âd́ŝ-t́ô-ćôńt̂én̂t́ r̂át̂íô, ćâń îḿp̂áĉt́ ûśêŕ êx́p̂ér̂íêńĉé âńd̂ úl̂t́îḿât́êĺŷ úŝér̂ ŕêt́êńt̂íôń. T̂h́ê B́êt́t̂ér̂ Ád̂ś Ŝt́âńd̂ár̂d́ [r̂éĉóm̂ḿêńd̂ś ĥáv̂ín̂ǵ âń âd́ d̂én̂śît́ŷ b́êĺôẃ 30%](ĥt́t̂ṕŝ://ẃŵẃ.b̂ét̂t́êŕâd́ŝ.ór̂ǵ/m̂ób̂íl̂é-âd́-d̂én̂śît́ŷ-h́îǵĥér̂-t́ĥán̂-30/). [Ĺêár̂ń m̂ór̂é](ĥt́t̂ṕŝ://d́êv́êĺôṕêŕŝ.ǵôóĝĺê.ćôḿ/p̂úb̂ĺîśĥér̂-ád̂ś-âúd̂ít̂ś/r̂éf̂ér̂én̂ćê/áûd́ît́ŝ/v́îéŵṕôŕt̂-ád̂-d́êńŝít̂ý)."
   },
   "audits/viewport-ad-density.js | displayValue": {
-    "message": "{adDensity, number, percent} ĉóv̂ér̂éd̂ b́ŷ ád̂ś"
+    "message": "{adDensity, number, percent} âd́ d̂én̂śît́ŷ"
   },
   "audits/viewport-ad-density.js | failureTitle": {
-    "message": "R̂éd̂úĉé âd́ d̂én̂śît́ŷ ín̂ ín̂ít̂íâĺ v̂íêẃp̂ór̂t́"
+    "message": "R̂éd̂úĉé âd́ d̂én̂śît́ŷ"
   },
   "audits/viewport-ad-density.js | title": {
-    "message": "Âd́ d̂én̂śît́ŷ ín̂ ín̂ít̂íâĺ v̂íêẃp̂ór̂t́ îś ŵít̂h́îń r̂éĉóm̂ḿêńd̂éd̂ ŕâńĝé"
+    "message": "Âd́ d̂én̂śît́ŷ íŝ ẃît́ĥín̂ ŕêćôḿm̂én̂d́êd́ r̂án̂ǵê"
   },
   "messages/common-strings.js | ERRORS__AREA_LARGER_THAN_VIEWPORT": {
     "message": "Ĉál̂ćûĺât́êd́ âd́ âŕêá îś l̂ár̂ǵêŕ t̂h́âń v̂íêẃp̂ór̂t́"

--- a/lighthouse-plugin-publisher-ads/test/audits/viewport-ad-density_test.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/viewport-ad-density_test.js
@@ -59,7 +59,29 @@ describe('ViewportAdDensity', () => {
       expect(result).to.have.property('numericValue', 150 / 425);
     });
 
-    it('should throw error if ad area exceeds viewport area', async () => {
+    it('should de-dupe overlapping ads', async () => {
+      const IFrameElements = [
+        generateSlot({left: 0, top: 0, w: 1000, h: 100}),
+        generateSlot({left: 0, top: 25, w: 600, h: 50}),
+      ];
+
+      const artifacts = {IFrameElements, ViewportDimensions};
+      const result = ViewportAdDensity.audit(artifacts);
+      expect(result).to.have.property('numericValue', 100 / 250);
+    });
+
+    it('should de-dupe overlapping ads when unsorted', async () => {
+      const IFrameElements = [
+        generateSlot({left: 0, top: 0, w: 1000, h: 100}),
+        generateSlot({left: 0, top: 25, w: 600, h: 50}),
+      ];
+
+      const artifacts = {IFrameElements, ViewportDimensions};
+      const result = ViewportAdDensity.audit(artifacts);
+      expect(result).to.have.property('numericValue', 100 / 250);
+    });
+
+    it('should clamp values at 100% density', async () => {
       const IFrameElements = [
         generateSlot({left: 0, top: 0, w: 1000, h: 400}),
         generateSlot({left: 0, top: 0, w: 600, h: 700}),
@@ -67,7 +89,7 @@ describe('ViewportAdDensity', () => {
 
       const artifacts = {IFrameElements, ViewportDimensions};
       const result = ViewportAdDensity.audit(artifacts);
-      expect(result).to.have.property('numericValue', 700 / 900);
+      expect(result).to.have.property('numericValue', 1);
     });
 
     it('should throw error if viewport area is zero', async () => {
@@ -80,17 +102,17 @@ describe('ViewportAdDensity', () => {
     });
 
     const positiveTests = [
-      {left: 10, top: 10, w: 10, h: 10, overlap: 100, pos: 'inside'},
+      {left: 10, top: 10, w: 10, h: 10, density: 10 / 215, pos: 'inside'},
       // Cases overlapping an edge of the viewport
-      {left: -10, top: 0, w: 20, h: 200, overlap: 2000, pos: 'left edge'},
-      {left: 0, top: -10, w: 300, h: 20, overlap: 3000, pos: 'top edge'},
-      {left: 290, top: 0, w: 20, h: 200, overlap: 2000, pos: 'right edge'},
-      {left: 0, top: 190, w: 300, h: 20, overlap: 3000, pos: 'bottom edge'},
+      {left: -10, top: 0, w: 20, h: 200, density: 2 / 3, pos: 'left edge'},
+      {left: 0, top: -10, w: 300, h: 20, density: 10 / 200, pos: 'top edge'},
+      {left: 290, top: 0, w: 20, h: 200, density: 2 / 3, pos: 'right edge'},
+      {left: 0, top: 190, w: 300, h: 20, density: 1 / 20, pos: 'bottom edge'},
       // Cases overlapping a corner of the viewport
-      {left: -10, top: -10, w: 20, h: 20, overlap: 100, pos: 'top left corner'},
-      {left: 290, top: -10, w: 20, h: 20, overlap: 100, pos: 'top right corner'},
-      {left: -10, top: 190, w: 20, h: 20, overlap: 100, pos: 'bottom left corner'},
-      {left: 290, top: 190, w: 20, h: 20, overlap: 100, pos: 'bottom right corner'},
+      {left: -10, top: -10, w: 20, h: 20, density: 0.05, pos: 'top left corner'},
+      {left: 290, top: -10, w: 20, h: 20, density: 0.05, pos: 'top right corner'},
+      {left: -10, top: 190, w: 20, h: 20, density: 0.05, pos: 'bottom left corner'},
+      {left: 290, top: 190, w: 20, h: 20, density: 0.05, pos: 'bottom right corner'},
     ];
 
     positiveTests.forEach(async (test) =>
@@ -98,7 +120,7 @@ describe('ViewportAdDensity', () => {
         const IFrameElements = [generateSlot(test)];
         const artifacts = {IFrameElements, ViewportDimensions};
         const result = ViewportAdDensity.audit(artifacts);
-        expect(result).to.have.property('numericValue', test.overlap / 60000);
+        expect(result).to.have.property('numericValue', test.density);
       })
     );
 
@@ -107,7 +129,6 @@ describe('ViewportAdDensity', () => {
       {left: -20, top: 0, w: 20, h: 200, pos: 'left edge'},
       {left: 0, top: -20, w: 300, h: 20, pos: 'top edge'},
       {left: 300, top: 0, w: 20, h: 200, pos: 'right edge'},
-      {left: 0, top: 200, w: 300, h: 20, pos: 'bottom edge'},
       // Cases outside a corner of the viewport
       {left: -20, top: -20, w: 20, h: 20, pos: 'top left corner'},
       {left: 300, top: -20, w: 20, h: 20, pos: 'top right corner'},

--- a/lighthouse-plugin-publisher-ads/test/audits/viewport-ad-density_test.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/viewport-ad-density_test.js
@@ -44,9 +44,10 @@ describe('ViewportAdDensity', () => {
       expect(result).to.have.property('notApplicable', true);
     });
 
-    it('should return ad density inside viewport', async () => {
+    it('should return ad density along a vertical axis', async () => {
       const IFrameElements = [
         generateSlot({left: 0, top: 100, w: 50, h: 50}), // in
+        generateSlot({left: 25, top: 50, w: 50, h: 50}), // in
         generateSlot({left: 100, top: 0, w: 50, h: 50}), // in
         generateSlot({left: 0, top: 200, w: 50, h: 50}), // out
         generateSlot({left: 0, top: 0, w: 0, h: 0}), // hidden
@@ -55,7 +56,7 @@ describe('ViewportAdDensity', () => {
 
       const artifacts = {IFrameElements, ViewportDimensions};
       const result = ViewportAdDensity.audit(artifacts);
-      expect(result).to.have.property('numericValue', 50 / 600);
+      expect(result).to.have.property('numericValue', 150 / 425);
     });
 
     it('should throw error if ad area exceeds viewport area', async () => {
@@ -65,7 +66,8 @@ describe('ViewportAdDensity', () => {
       ];
 
       const artifacts = {IFrameElements, ViewportDimensions};
-      expect(() => ViewportAdDensity.audit(artifacts)).to.throw();
+      const result = ViewportAdDensity.audit(artifacts);
+      expect(result).to.have.property('numericValue', 700 / 900);
     });
 
     it('should throw error if viewport area is zero', async () => {

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/lazy-load.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/lazy-load.js
@@ -34,8 +34,8 @@ module.exports = [
           },
         },
         'viewport-ad-density': {
-          score: 0,
-          numericValue: '.408 +/- .001',
+          score: 1,
+          numericValue: '.10 +/- .01',
         },
         'ads-in-viewport': {
           score: 0,


### PR DESCRIPTION
Closes #209 

Note the better ads standard defines ad density as the ratio between sum of ad heights over content length, but content length is not well defined. It should include logos and footers, but it can be challenging to measure with lazy loading if not all ads are loaded immediately. For synthetic testing, I chose the content length to be 1 viewport after the midpoint of the last ad.

On desktop we measure each column of ads separately.