### PR TITLE
New audit for a total ad blocking time metric

### DIFF
--- a/lighthouse-plugin-publisher-ads/audits/total-ad-blocking-time.js
+++ b/lighthouse-plugin-publisher-ads/audits/total-ad-blocking-time.js
@@ -10,6 +10,7 @@
 
 const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
 const LongTasks = require('../computed/long-tasks');
+const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {getAttributableUrl} = require('../utils/tasks');
@@ -94,6 +95,10 @@ class TotalAdBlockingTime extends Audit {
     const LONG_TASK_DUR_MS = 50;
     const trace = artifacts.traces[Audit.DEFAULT_PASS];
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
+    const networkRecords = await NetworkRecords.request(devtoolsLog, context);
+    if (!networkRecords.find((r) => isAdRelated(r.url))) {
+      return auditNotApplicable.NoAdRelatedReq;
+    }
     const metricData = {trace, devtoolsLog, settings: context.settings};
     let longTasks = [];
     try {

--- a/lighthouse-plugin-publisher-ads/audits/total-ad-blocking-time.js
+++ b/lighthouse-plugin-publisher-ads/audits/total-ad-blocking-time.js
@@ -1,0 +1,150 @@
+// Copyright 2021 Google LLC
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const AdRequestTime = require('../computed/ad-request-time');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
+const LongTasks = require('../computed/long-tasks');
+const {auditNotApplicable} = require('../messages/common-strings');
+const {Audit} = require('lighthouse');
+const {getAttributableUrl} = require('../utils/tasks');
+const {isAdRelated, getNameOrTld} = require('../utils/resource-classification');
+const {URL} = require('url');
+
+const UIStrings = {
+  /* Title of the audit */
+  title: 'Total ad JS blocking time',
+  failureTitle: 'Reduce ad JS blocking time',
+  description: 'Ad-related scripts are blocking the main thread.' ,
+  failureDisplayValue: '{timeInMs, number, seconds} s blocked',
+  columnName: 'Name',
+  columnBlockingTime: 'Blocking Time',
+};
+
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+/**
+ * @typedef {Object} TableRow
+ * @property {number} blockingTime
+ * @property {string} name
+ */
+
+/**
+ * Table headings for audits details sections.
+ * @type {LH.Audit.Details.Table['headings']}
+ */
+const HEADINGS = [
+  {
+    key: 'name',
+    itemType: 'text',
+    text: str_(UIStrings.columnName),
+  },
+  {
+    key: 'blockingTime',
+    itemType: 'ms',
+    text: str_(UIStrings.columnBlockingTime),
+    granularity: 1,
+  },
+];
+
+/** @inheritDoc */
+class TotalAdBlockingTime extends Audit {
+  /**
+   * @return {LH.Audit.Meta}
+   * @override
+   */
+  static get meta() {
+    return {
+      id: 'total-ad-blocking-time',
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
+      description: str_(UIStrings.description),
+      requiredArtifacts: ['traces', 'devtoolsLogs'],
+    };
+  }
+
+  /**
+   * @return {{
+    *  simulate: LH.Audit.ScoreOptions, provided: LH.Audit.ScoreOptions,
+    * }}
+    */
+  static get defaultOptions() {
+    return {
+      simulate: {
+        p10: 290,
+        median: 600,
+      },
+      provided: {
+        p10: 150,
+        median: 350,
+      },
+    };
+  }
+
+  /**
+   * @param {LH.Artifacts} artifacts
+   * @param {LH.Audit.Context} context
+   * @return {Promise<LH.Audit.Product>}
+   * @override
+   */
+  static async audit(artifacts, context) {
+    const LONG_TASK_DUR_MS = 50;
+    const trace = artifacts.traces[Audit.DEFAULT_PASS];
+    const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
+    const metricData = {trace, devtoolsLog, settings: context.settings};
+    let longTasks = [];
+    try {
+      longTasks = await LongTasks.request(metricData, context);
+    } catch (e) {
+      return auditNotApplicable.InvalidTiming;
+    }
+
+    let totalAdJsBlockingTime = 0;
+    /** @type {Map<string, number>} */ const adBlockingTimeByParty = new Map();
+    for (const longTask of longTasks) {
+      const scriptUrl = getAttributableUrl(longTask);
+      if (!scriptUrl || !isAdRelated(scriptUrl)) {
+        // Don't count non-ads scripts here.
+        continue;
+      }
+      if (longTask.parent) {
+        // Only show top-level tasks (i.e. ones with no parents).
+        continue;
+      }
+      // Count excess long task time as "blocking time"
+      const blockingTime = longTask.duration - LONG_TASK_DUR_MS;
+      totalAdJsBlockingTime += blockingTime;
+
+      const party = getNameOrTld(scriptUrl);
+      const prevBlockingTime = adBlockingTimeByParty.get(party) || 0;
+      adBlockingTimeByParty.set(party, prevBlockingTime + blockingTime);
+    }
+
+    /** @type {TableRow[]} */ const tableDetails = [];
+    for (const [name, blockingTime] of adBlockingTimeByParty.entries()) {
+      tableDetails.push({name, blockingTime});
+    }
+    // Sort in descending order
+    tableDetails.sort((a, b) => b.blockingTime - a.blockingTime);
+
+    const scoreOptions = context.options[context.settings.throttlingMethod]
+       || context.options['provided'];
+
+    return {
+      score: Audit.computeLogNormalScore(scoreOptions, totalAdJsBlockingTime),
+      numericValue: totalAdJsBlockingTime,
+      numericUnit: 'millisecond',
+      displayValue:
+        str_(UIStrings.failureDisplayValue, {timeInMs: totalAdJsBlockingTime}),
+      details: TotalAdBlockingTime.makeTableDetails(HEADINGS, tableDetails),
+    };
+  }
+}
+
+module.exports = TotalAdBlockingTime;
+module.exports.UIStrings = UIStrings;

--- a/lighthouse-plugin-publisher-ads/audits/total-ad-blocking-time.js
+++ b/lighthouse-plugin-publisher-ads/audits/total-ad-blocking-time.js
@@ -8,20 +8,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const AdRequestTime = require('../computed/ad-request-time');
 const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
 const LongTasks = require('../computed/long-tasks');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {getAttributableUrl} = require('../utils/tasks');
 const {isAdRelated, getNameOrTld} = require('../utils/resource-classification');
-const {URL} = require('url');
 
 const UIStrings = {
   /* Title of the audit */
   title: 'Total ad JS blocking time',
   failureTitle: 'Reduce ad JS blocking time',
-  description: 'Ad-related scripts are blocking the main thread.' ,
+  description: 'Ad-related scripts are blocking the main thread.',
   failureDisplayValue: '{timeInMs, number, seconds} s blocked',
   columnName: 'Name',
   columnBlockingTime: 'Blocking Time',

--- a/lighthouse-plugin-publisher-ads/lighthouse-plugin-publisher-ads
+++ b/lighthouse-plugin-publisher-ads/lighthouse-plugin-publisher-ads
@@ -1,0 +1,1 @@
+../../lighthouse-plugin-publisher-ads

--- a/lighthouse-plugin-publisher-ads/lighthouse-plugin-publisher-ads
+++ b/lighthouse-plugin-publisher-ads/lighthouse-plugin-publisher-ads
@@ -1,1 +1,0 @@
-../../lighthouse-plugin-publisher-ads

--- a/lighthouse-plugin-publisher-ads/messages/en-US.json
+++ b/lighthouse-plugin-publisher-ads/messages/en-US.json
@@ -539,6 +539,30 @@
     "message": "Tag load time",
     "description": ""
   },
+  "audits/total-ad-blocking-time.js | columnBlockingTime": {
+    "message": "Blocking Time",
+    "description": ""
+  },
+  "audits/total-ad-blocking-time.js | columnName": {
+    "message": "Name",
+    "description": ""
+  },
+  "audits/total-ad-blocking-time.js | description": {
+    "message": "Ad-related scripts are blocking the main thread.",
+    "description": ""
+  },
+  "audits/total-ad-blocking-time.js | failureDisplayValue": {
+    "message": "{timeInMs, number, seconds} s blocked",
+    "description": ""
+  },
+  "audits/total-ad-blocking-time.js | failureTitle": {
+    "message": "Reduce ad JS blocking time",
+    "description": ""
+  },
+  "audits/total-ad-blocking-time.js | title": {
+    "message": "Total ad JS blocking time",
+    "description": "Title of the audit"
+  },
   "audits/viewport-ad-density.js | description": {
     "message": "Ad density, the ads-to-content ratio, can impact user experience and ultimately user retention. The Better Ads Standard [recommends having an ad density below 30%](https://www.betterads.org/mobile-ad-density-higher-than-30/). [Learn more](https://developers.google.com/publisher-ads-audits/reference/audits/viewport-ad-density).",
     "description": ""

--- a/lighthouse-plugin-publisher-ads/messages/locales/en-XL.json
+++ b/lighthouse-plugin-publisher-ads/messages/locales/en-XL.json
@@ -404,6 +404,24 @@
   "audits/tag-load-time.js | title": {
     "message": "T̂áĝ ĺôád̂ t́îḿê"
   },
+  "audits/total-ad-blocking-time.js | columnBlockingTime": {
+    "message": "B̂ĺôćk̂ín̂ǵ T̂ím̂é"
+  },
+  "audits/total-ad-blocking-time.js | columnName": {
+    "message": "N̂ám̂é"
+  },
+  "audits/total-ad-blocking-time.js | description": {
+    "message": "Âd́-r̂él̂át̂éd̂ śĉŕîṕt̂ś âŕê b́l̂óĉḱîńĝ t́ĥé m̂áîń t̂h́r̂éâd́."
+  },
+  "audits/total-ad-blocking-time.js | failureDisplayValue": {
+    "message": "{timeInMs, number, seconds} ŝ b́l̂óĉḱêd́"
+  },
+  "audits/total-ad-blocking-time.js | failureTitle": {
+    "message": "R̂éd̂úĉé âd́ ĴŚ b̂ĺôćk̂ín̂ǵ t̂ím̂é"
+  },
+  "audits/total-ad-blocking-time.js | title": {
+    "message": "T̂ót̂ál̂ ád̂ J́Ŝ b́l̂óĉḱîńĝ t́îḿê"
+  },
   "audits/viewport-ad-density.js | description": {
     "message": "Âd́ d̂én̂śît́ŷ, t́ĥé âd́ŝ-t́ô-ćôńt̂én̂t́ r̂át̂íô, ćâń îḿp̂áĉt́ ûśêŕ êx́p̂ér̂íêńĉé âńd̂ úl̂t́îḿât́êĺŷ úŝér̂ ŕêt́êńt̂íôń. T̂h́ê B́êt́t̂ér̂ Ád̂ś Ŝt́âńd̂ár̂d́ [r̂éĉóm̂ḿêńd̂ś ĥáv̂ín̂ǵ âń âd́ d̂én̂śît́ŷ b́êĺôẃ 30%](ĥt́t̂ṕŝ://ẃŵẃ.b̂ét̂t́êŕâd́ŝ.ór̂ǵ/m̂ób̂íl̂é-âd́-d̂én̂śît́ŷ-h́îǵĥér̂-t́ĥán̂-30/). [Ĺêár̂ń m̂ór̂é](ĥt́t̂ṕŝ://d́êv́êĺôṕêŕŝ.ǵôóĝĺê.ćôḿ/p̂úb̂ĺîśĥér̂-ád̂ś-âúd̂ít̂ś/r̂éf̂ér̂én̂ćê/áûd́ît́ŝ/v́îéŵṕôŕt̂-ád̂-d́êńŝít̂ý)."
   },

--- a/lighthouse-plugin-publisher-ads/plugin.js
+++ b/lighthouse-plugin-publisher-ads/plugin.js
@@ -49,6 +49,7 @@ module.exports = {
     {path: `${PLUGIN_PATH}/audits/cumulative-ad-shift`},
     {path: `${PLUGIN_PATH}/audits/deprecated-api-usage`},
     {path: `${PLUGIN_PATH}/audits/gpt-errors-overall`},
+    {path: `${PLUGIN_PATH}/audits/total-ad-blocking-time`},
   ],
   groups: {
     'metrics': {
@@ -71,6 +72,7 @@ module.exports = {
       {id: 'ad-request-from-page-start', weight: 25, group: 'metrics'},
       {id: 'first-ad-render', weight: 10, group: 'metrics'},
       {id: 'cumulative-ad-shift', weight: 5, group: 'metrics'},
+      {id: 'total-ad-blocking-time', weight: 2, group: 'metrics'},
       // Performance group.
       {id: 'gpt-bids-parallel', weight: 1, group: 'ads-performance'},
       {id: 'serial-header-bidding', weight: 1, group: 'ads-performance'},

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/not-applicable.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/not-applicable.js
@@ -45,6 +45,7 @@ module.exports = [
         'script-injected-tags': {scoreDisplayMode: 'notApplicable'},
         'serial-header-bidding': {scoreDisplayMode: 'notApplicable'},
         'tag-load-time': {scoreDisplayMode: 'notApplicable'},
+        'total-ad-blocking-time': {scoreDisplayMode: 'notApplicable'},
         'viewport-ad-density': {scoreDisplayMode: 'notApplicable'},
       },
     },

--- a/lighthouse-plugin-publisher-ads/utils/resource-classification.js
+++ b/lighthouse-plugin-publisher-ads/utils/resource-classification.js
@@ -188,7 +188,7 @@ function isGpt(url) {
 
 /**
  * Checks if the url is loading amp-ad script.
- * @param {URL} url
+ * @param {URL|string} url
  * @return {boolean}
  */
 function isAMP(url) {
@@ -236,7 +236,7 @@ function isGptIframe(iframe) {
 
 /**
  * Checks if the url is loading an AdSense or GPT loader script.
- * @param {URL} url
+ * @param {URL|string} url
  * @return {boolean}
  */
 function isAdTag(url) {
@@ -245,7 +245,7 @@ function isAdTag(url) {
 
 /**
  * Checks if the url is loading an AdSense or GPT loader or impl script.
- * @param {URL} url
+ * @param {URL|string} url
  * @return {boolean}
  */
 function isAdScript(url) {
@@ -397,6 +397,21 @@ function getNameOrTld(url) {
   return tld || host;
 }
 
+/**
+ * @param {string} url
+ * @return {boolean}
+ */
+function isAdRelated(url) {
+  if (isAdScript(url) || getHeaderBidder(url)) {
+    return true;
+  }
+  const thirdPartyEntity = thirdPartyWeb.getEntity(url);
+  if (thirdPartyEntity) {
+    return thirdPartyEntity.categories.includes('ad');
+  }
+  return false;
+}
+
 module.exports = {
   isGoogleAds,
   isGptAdRequest,
@@ -426,4 +441,5 @@ module.exports = {
   getNameOrTld,
   isAMPTag,
   isAMPAdRequest,
+  isAdRelated,
 };


### PR DESCRIPTION
Note this takes a slightly different approach by having a table under the metrics section

Docs to come in a follow-up PR