### PR TITLE
Update cumulative ad shift computation

### DIFF
--- a/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
+++ b/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
@@ -71,20 +71,19 @@ class CumulativeAdShift extends Audit {
     if (!shiftEvent.args || !shiftEvent.args.data) {
       return false;
     }
-    for (const ad of ads) {
-      const adRect = ad.clientRect;
-      // Names come from external JSON
+    // Names come from external JSON
+    // eslint-disable-next-line camelcase
+    for (const node of shiftEvent.args.data.impacted_nodes || []) {
       // eslint-disable-next-line camelcase
-      const impactedNodes = shiftEvent.args.data.impacted_nodes || [];
-      for (const node of impactedNodes) {
-        // eslint-disable-next-line camelcase
-        const oldRect = toClientRect(node.old_rect || []);
-        const newRect = toClientRect(node.new_rect || []);
-        if (oldRect.top > newRect.top || oldRect.height !== newRect.height) {
-          // It wasn't a downward shift. I.e. this element wasn't pushed down
-          // by an ad.
-          continue;
-        }
+      const oldRect = toClientRect(node.old_rect || []);
+      const newRect = toClientRect(node.new_rect || []);
+      if (oldRect.top > newRect.top || oldRect.height !== newRect.height) {
+        // It wasn't a downward shift. I.e. this element wasn't pushed down
+        // by an ad.
+        continue;
+      }
+      for (const ad of ads) {
+        const adRect = ad.clientRect;
         if (oldRect.top >= adRect.top && newRect.top > adRect.bottom &&
             overlaps(oldRect, adRect)) {
           return true;

--- a/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
+++ b/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
@@ -65,6 +65,7 @@ class CumulativeAdShift extends Audit {
   /**
    * @param {LH.TraceEvent} shiftEvent
    * @param {Artifacts['IFrameElement'][]} ads
+   * @return {boolean}
    */
   static isAdExpansion(shiftEvent, ads) {
     if (!shiftEvent.args || !shiftEvent.args.data) {
@@ -100,6 +101,7 @@ class CumulativeAdShift extends Audit {
   /**
    * @param {LH.TraceEvent} shiftEvent
    * @param {LH.TraceEvent[]} tasks
+   * @return {boolean}
    */
   static isAttributableToTask(shiftEvent, tasks) {
     if (!shiftEvent.args || !shiftEvent.args.data) {

--- a/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
+++ b/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
@@ -16,7 +16,7 @@ const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {getScriptUrl} = require('../utils/network-timing');
-const {isAdIframe, isGpt, isImplTag} = require('../utils/resource-classification');
+const {isAdIframe, isAdRelated, isImplTag} = require('../utils/resource-classification');
 const {overlaps, toClientRect} = require('../utils/geometry');
 
 const UIStrings = {
@@ -172,7 +172,7 @@ class CumulativeAdShift extends Audit {
       return auditNotApplicable.NoLayoutShifts;
     }
     const scriptEvents =
-        trace.traceEvents.filter((e) => isGpt(getScriptUrl(e) || ''));
+        trace.traceEvents.filter((e) => isAdRelated(getScriptUrl(e) || ''));
 
     const tagLoadEvent =
         scriptEvents.find((e) => isImplTag(getScriptUrl(e) || '')) ||

--- a/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
+++ b/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
@@ -175,14 +175,15 @@ class CumulativeAdShift extends Audit {
     // Maybe we should look at the parent elements (created by the publisher and
     // passed to the ad tag) rather than the iframe itself.
     const ads = artifacts.IFrameElements.filter(isAdIframe);
-    if (!ads.length) {
+    const details =
+        this.compute(shiftEvents, scriptEvents, ads, tagLoadEvent.ts);
+    const rawScore = details.cumulativeAdShift;
+
+    if (!ads.length && !rawScore) {
       // TODO count shifts for the container element here.
       return auditNotApplicable.NoAdRendered;
     }
 
-    const details =
-        this.compute(shiftEvents, scriptEvents, ads, tagLoadEvent.ts);
-    const rawScore = details.cumulativeAdShift;
     return {
       numericValue: rawScore,
       numericUnit: 'unitless',

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/cumulative-ad-shift.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/cumulative-ad-shift.js
@@ -23,7 +23,7 @@ module.exports = [
       finalUrl: 'http://localhost:8081/layout-shift.html',
       audits: {
         'cumulative-ad-shift': {
-          numericValue: '0.25 +/- 0.05',
+          numericValue: '0.33 +/- 0.05',
           details: {
             numShifts: 4,
             numAdShifts: 3,

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/cumulative-ad-shift.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/cumulative-ad-shift.js
@@ -23,10 +23,10 @@ module.exports = [
       finalUrl: 'http://localhost:8081/layout-shift.html',
       audits: {
         'cumulative-ad-shift': {
-          displayValue: '0.26',
+          displayValue: '0.25 +/- 0.05',
           details: {
             numShifts: 4,
-            numAdShifts: 4,
+            numAdShifts: 3,
           },
         },
       },

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/cumulative-ad-shift.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/cumulative-ad-shift.js
@@ -23,10 +23,10 @@ module.exports = [
       finalUrl: 'http://localhost:8081/layout-shift.html',
       audits: {
         'cumulative-ad-shift': {
-          score: null,
+          displayValue: '0.04',
           details: {
-            numShifts: 2,
-            numAdShifts: 2,
+            numShifts: 4,
+            numAdShifts: 4,
           },
         },
       },

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/cumulative-ad-shift.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/cumulative-ad-shift.js
@@ -23,7 +23,7 @@ module.exports = [
       finalUrl: 'http://localhost:8081/layout-shift.html',
       audits: {
         'cumulative-ad-shift': {
-          displayValue: '0.25 +/- 0.05',
+          numericValue: '0.25 +/- 0.05',
           details: {
             numShifts: 4,
             numAdShifts: 3,

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/cumulative-ad-shift.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/cumulative-ad-shift.js
@@ -1,0 +1,35 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+/**
+ * Expected Lighthouse audit values for perf tests.
+ */
+module.exports = [
+  {
+    lhr: {
+      requestedUrl: 'http://localhost:8081/layout-shift.html',
+      finalUrl: 'http://localhost:8081/layout-shift.html',
+      audits: {
+        'cumulative-ad-shift': {
+          score: null,
+          details: {
+            numShifts: 2,
+            numAdShifts: 2,
+          },
+        },
+      },
+    },
+  },
+];

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/cumulative-ad-shift.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/cumulative-ad-shift.js
@@ -23,7 +23,7 @@ module.exports = [
       finalUrl: 'http://localhost:8081/layout-shift.html',
       audits: {
         'cumulative-ad-shift': {
-          displayValue: '0.04',
+          displayValue: '0.26',
           details: {
             numShifts: 4,
             numAdShifts: 4,

--- a/lighthouse-plugin-publisher-ads/test/smoke/fixtures/layout-shift.html
+++ b/lighthouse-plugin-publisher-ads/test/smoke/fixtures/layout-shift.html
@@ -38,13 +38,11 @@
               .addService(googletag.pubads());
       });
       googletag.cmd.push(function() {
-        // googletag.pubads().enableSingleRequest();
         googletag.enableServices();
         googletag.pubads().addEventListener('slotRenderEnded', function(evt) {
           setTimeout(function() {
-            const el = document.getElementById(evt.slot.getSlotElementId());
-            el.style.height = '40px';
-          }, 1000);
+            googletag.pubads().clear([evt.slot]);
+          }, Math.round(1000 + 1000 * Math.random()));
         });
       });
     </script>

--- a/lighthouse-plugin-publisher-ads/test/smoke/fixtures/layout-shift.html
+++ b/lighthouse-plugin-publisher-ads/test/smoke/fixtures/layout-shift.html
@@ -38,15 +38,24 @@
               .addService(googletag.pubads());
       });
       googletag.cmd.push(function() {
-        googletag.pubads().enableSingleRequest();
+        // googletag.pubads().enableSingleRequest();
         googletag.enableServices();
+        googletag.pubads().addEventListener('slotRenderEnded', function(evt) {
+          setTimeout(function() {
+            const el = document.getElementById(evt.slot.getSlotElementId());
+            el.style.height = '40px';
+          }, 1000);
+        });
       });
     </script>
   </head>
   <body>
+    <p> Hi! </p>
     <div id="div0" style="width: 728px;">
       <script>
-        googletag.cmd.push(function() { googletag.display('div0'); });
+        setTimeout(function() {
+          googletag.cmd.push(function() { googletag.display('div0'); });
+        }, 1000);
       </script>
     </div>
 

--- a/lighthouse-plugin-publisher-ads/test/smoke/fixtures/layout-shift.html
+++ b/lighthouse-plugin-publisher-ads/test/smoke/fixtures/layout-shift.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<!--
+* Copyright 2021 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+-->
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>GPT Layout Shift Test</title>
+    <style>
+      p {
+        font-size: 50px;
+      }
+    </style>
+    <script>googletag = window.googletag || {cmd: []};</script>
+    <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+    <script>
+      googletag.cmd.push(() => {
+          googletag.defineSlot('/6355419/Travel', [728, 90], 'div0')
+              .setTargeting("test","infinitescroll")
+              .addService(googletag.pubads());
+      });
+      googletag.cmd.push(() => {
+          googletag.defineSlot('/6355419/Travel', [728, 90], 'div1')
+              .setTargeting("test","infinitescroll")
+              .addService(googletag.pubads());
+      });
+      googletag.cmd.push(function() {
+        googletag.pubads().enableSingleRequest();
+        googletag.enableServices();
+        googletag.pubads().addEventListener('slotRenderEnded', function(e) {
+          setTimeout(function() {
+            googletag.pubads().clear([e.slot]);
+          }, 1000);
+        });
+      });
+    </script>
+  </head>
+  <body>
+    <div id="div0" style="width: 728px;">
+      <script>
+        googletag.cmd.push(function() { googletag.display('div0'); });
+      </script>
+    </div>
+
+    <div id="div1" style="width: 728px;">
+      <script>
+        googletag.cmd.push(function() { googletag.display('div1'); });
+      </script>
+    </div>
+
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut pretium justo 
+        enim. Vivamus non congue ligula, non pulvinar risus. Ut sodales pulvinar 
+        sem, et semper mi fringilla quis. Donec ac lacus orci. Sed pharetra eros 
+        et risus egestas fermentum. Cras pulvinar metus tempus, varius nunc ut, 
+        ullamcorper massa. Nam tempus imperdiet molestie. Mauris et bibendum 
+        lorem. Nunc metus leo, rhoncus quis mollis nec, ultricies a erat. 
+        Suspendisse sed auctor mauris, sit amet faucibus neque. Praesent commodo 
+        tortor et lorem imperdiet, ac interdum massa molestie. Aliquam in 
+        bibendum sem. Duis bibendum ex dolor, et molestie sem aliquam non. Duis 
+        eu risus nec lectus maximus imperdiet. In mi velit, varius sit amet enim 
+        a, semper tristique sapien. Nulla in leo sed nibh dictum pharetra rhoncus 
+        id lacus.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut pretium justo 
+        enim. Vivamus non congue ligula, non pulvinar risus. Ut sodales pulvinar 
+        sem, et semper mi fringilla quis. Donec ac lacus orci. Sed pharetra eros 
+        et risus egestas fermentum. Cras pulvinar metus tempus, varius nunc ut, 
+        ullamcorper massa. Nam tempus imperdiet molestie. Mauris et bibendum 
+        lorem. Nunc metus leo, rhoncus quis mollis nec, ultricies a erat. 
+        Suspendisse sed auctor mauris, sit amet faucibus neque. Praesent commodo 
+        tortor et lorem imperdiet, ac interdum massa molestie. Aliquam in 
+        bibendum sem. Duis bibendum ex dolor, et molestie sem aliquam non. Duis 
+        eu risus nec lectus maximus imperdiet. In mi velit, varius sit amet enim 
+        a, semper tristique sapien. Nulla in leo sed nibh dictum pharetra rhoncus 
+        id lacus.
+      </p>
+
+  </body>
+</html>

--- a/lighthouse-plugin-publisher-ads/test/smoke/fixtures/layout-shift.html
+++ b/lighthouse-plugin-publisher-ads/test/smoke/fixtures/layout-shift.html
@@ -40,11 +40,6 @@
       googletag.cmd.push(function() {
         googletag.pubads().enableSingleRequest();
         googletag.enableServices();
-        googletag.pubads().addEventListener('slotRenderEnded', function(e) {
-          setTimeout(function() {
-            googletag.pubads().clear([e.slot]);
-          }, 1000);
-        });
       });
     </script>
   </head>

--- a/lighthouse-plugin-publisher-ads/test/smoke/smoke-test-dfns.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/smoke-test-dfns.js
@@ -65,6 +65,11 @@ const smokeTests = [
     expectations: require('./expectations/limited-ads-dynamic-loading.js'),
     config: require('./config.js'),
   },
+  {
+    id: 'cumulative-ad-shift',
+    expectations: require('./expectations/cumulative-ad-shift.js'),
+    config: require('./config.js'),
+  },
 ];
 
 module.exports = smokeTests;


### PR DESCRIPTION
- Don't count cases where an ad shifted but didn't cause the shift. Note that this approach only counts expansions (not shrinking/collapsing) since we only know the final ad size. Thanks @jonkeller for developing the algorithm.
- Count layout shifts that occur a frame after an ad script executes as an ad-attributable layout shift. This should capture shrinking/collapsing by GPT.