### PR TITLE
Revert unintended changes to audit documentation

### DIFF
--- a/docs/audits/script-injected-tags.md
+++ b/docs/audits/script-injected-tags.md
@@ -63,7 +63,7 @@ hover over the source link to see all of the calls leading up to the request.
 
 ## More information
 
-This audit operates against a whitelist of ad scripts which are known to be safe
+This audit operates against a allowlist of ad scripts which are known to be safe
 to load statically. The current list is:
 
 <table>

--- a/docs/audits/viewport-ad-density.md
+++ b/docs/audits/viewport-ad-density.md
@@ -1,10 +1,10 @@
-# Reduce ad density in initial viewport
+# Reduce ad density
 
 ## Overview
 
-This audit ensures that visible ads take up no more than 30% of the initial
-viewport. An ad density greater than this has been found to negatively impact
-user experience[^1].
+This audit ensures that ads take up no more than 30% of the page vertically. An
+ad density greater than 30% has been found to negatively impact user
+experience[^1].
 
 ## Recommendations
 
@@ -13,7 +13,14 @@ a reduced size.
 
 ## More information
 
+On mobile devices, we assume a single column layout and so all ads on the page
+are included in the ad density calculation. On desktop, we divide the page into
+multiple vertical slices to account for multi-column layouts. The audit measures
+ad density in each slice individually to ensure no individual slice exceeds the
+maximum recommended threshold.
+
+To account for lazy loading, we measure content length up to 1 viewport past the
+last ad. To measure ad density over the entire content, disable lazy loading.
+
 [Ad Experience: Ad Density Higher Than 30%](https://www.betterads.org/mobile-ad-density-higher-than-30/)  
 [What publishers need to know now about creating a better ad experience](https://www.thinkwithgoogle.com/marketing-resources/better-ad-standards/)
-
-[^1]: Coalition for Better Ads. ["Determining a Better Ads Standard Based on User Experience Data"](https://www.betterads.org/research/standardpaper/). 2017.

--- a/docs/audits/viewport-ad-density.md
+++ b/docs/audits/viewport-ad-density.md
@@ -24,3 +24,6 @@ last ad. To measure ad density over the entire content, disable lazy loading.
 
 [Ad Experience: Ad Density Higher Than 30%](https://www.betterads.org/mobile-ad-density-higher-than-30/)  
 [What publishers need to know now about creating a better ad experience](https://www.thinkwithgoogle.com/marketing-resources/better-ad-standards/)
+
+
+[^1]: Coalition for Better Ads. ["Determining a Better Ads Standard Based on User Experience Data"](https://www.betterads.org/research/standardpaper/). 2017.


### PR DESCRIPTION
Looks like Copybara incorrectly reverted some doc changes in https://github.com/googleads/publisher-ads-lighthouse-plugin/commit/a120680911a50ecb7c85e1814612cd9273c060f8. This was probably due to the original PRs being manually submitted before Copybara could import the changes.