### PR TITLE
be explicit about extensions when importing lighthouse modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ async function main() {
   }
 
   // @ts-ignore let LH handle the CLI
-  await require('lighthouse/lighthouse-cli/bin').begin();
+  await require('lighthouse/lighthouse-cli/bin.js').begin();
 }
 
 if (require.main == module) {

--- a/lighthouse-plugin-publisher-ads/audits/ad-blocking-tasks.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-blocking-tasks.js
@@ -8,7 +8,7 @@
 // limitations under the License.
 
 const AdRequestTime = require('../computed/ad-request-time');
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
 const LongTasks = require('../computed/long-tasks');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');

--- a/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
+const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
 // @ts-ignore
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');

--- a/lighthouse-plugin-publisher-ads/audits/ad-request-critical-path.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-critical-path.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {computeAdRequestWaterfall} = require('../utils/graph');

--- a/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 const ComputedAdRequestTime = require('../computed/ad-request-time');
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
 const {auditNotApplicable, runWarning} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 

--- a/lighthouse-plugin-publisher-ads/audits/ad-request-from-tag-load.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-from-tag-load.js
@@ -14,7 +14,7 @@
 
 const ComputedAdRequestTime = require('../computed/ad-request-time');
 const ComputedTagLoadTime = require('../computed/tag-load-time');
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 

--- a/lighthouse-plugin-publisher-ads/audits/ad-top-of-viewport.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-top-of-viewport.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {isAdIframe} = require('../utils/resource-classification');

--- a/lighthouse-plugin-publisher-ads/audits/ads-in-viewport.js
+++ b/lighthouse-plugin-publisher-ads/audits/ads-in-viewport.js
@@ -15,7 +15,7 @@
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
 const {isBoxInViewport} = require('../utils/geometry');
 const {isGptIframe} = require('../utils/resource-classification');
 

--- a/lighthouse-plugin-publisher-ads/audits/async-ad-tags.js
+++ b/lighthouse-plugin-publisher-ads/audits/async-ad-tags.js
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 const array = require('../utils/array.js');
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
 // @ts-ignore
-const MainResource = require('lighthouse/lighthouse-core/computed/main-resource');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
+const MainResource = require('lighthouse/lighthouse-core/computed/main-resource.js');
+const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {isAdTag, isStaticRequest} = require('../utils/resource-classification');

--- a/lighthouse-plugin-publisher-ads/audits/bid-request-from-page-start.js
+++ b/lighthouse-plugin-publisher-ads/audits/bid-request-from-page-start.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 const ComputedBidRequestTime = require('../computed/bid-request-time');
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 

--- a/lighthouse-plugin-publisher-ads/audits/blocking-load-events.js
+++ b/lighthouse-plugin-publisher-ads/audits/blocking-load-events.js
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
+const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
 // @ts-ignore
-const TraceOfTab = require('lighthouse/lighthouse-core/computed/trace-of-tab');
+const TraceOfTab = require('lighthouse/lighthouse-core/computed/trace-of-tab.js');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {computeAdRequestWaterfall} = require('../utils/graph');

--- a/lighthouse-plugin-publisher-ads/audits/bottleneck-requests.js
+++ b/lighthouse-plugin-publisher-ads/audits/bottleneck-requests.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {computeAdRequestWaterfall} = require('../utils/graph');

--- a/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
+++ b/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {getScriptUrl} = require('../utils/network-timing');

--- a/lighthouse-plugin-publisher-ads/audits/deprecated-api-usage.js
+++ b/lighthouse-plugin-publisher-ads/audits/deprecated-api-usage.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
+const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {isGpt, isGptImplTag} = require('../utils/resource-classification');

--- a/lighthouse-plugin-publisher-ads/audits/duplicate-tags.js
+++ b/lighthouse-plugin-publisher-ads/audits/duplicate-tags.js
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
 // @ts-ignore
-const MainResource = require('lighthouse/lighthouse-core/computed/main-resource');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
-const NetworkRequest = require('lighthouse/lighthouse-core/lib/network-request');
+const MainResource = require('lighthouse/lighthouse-core/computed/main-resource.js');
+const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
+const NetworkRequest = require('lighthouse/lighthouse-core/lib/network-request.js');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {containsAnySubstring} = require('../utils/resource-classification');

--- a/lighthouse-plugin-publisher-ads/audits/first-ad-render.js
+++ b/lighthouse-plugin-publisher-ads/audits/first-ad-render.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 const ComputedAdRenderTime = require('../computed/ad-render-time');
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
 const {auditNotApplicable, runWarning} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 

--- a/lighthouse-plugin-publisher-ads/audits/full-width-slots.js
+++ b/lighthouse-plugin-publisher-ads/audits/full-width-slots.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
+const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {isAdRequest} = require('../utils/resource-classification');

--- a/lighthouse-plugin-publisher-ads/audits/gpt-bids-parallel.js
+++ b/lighthouse-plugin-publisher-ads/audits/gpt-bids-parallel.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
+const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
 const {assert} = require('../utils/asserts');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');

--- a/lighthouse-plugin-publisher-ads/audits/gpt-errors-overall.js
+++ b/lighthouse-plugin-publisher-ads/audits/gpt-errors-overall.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
+const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {isGpt, isGptImplTag} = require('../utils/resource-classification');

--- a/lighthouse-plugin-publisher-ads/audits/idle-network-times.js
+++ b/lighthouse-plugin-publisher-ads/audits/idle-network-times.js
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
-const MainThreadTasks = require('lighthouse/lighthouse-core/computed/main-thread-tasks');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
+const MainThreadTasks = require('lighthouse/lighthouse-core/computed/main-thread-tasks.js');
+const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
 // @ts-ignore
-const TraceOfTab = require('lighthouse/lighthouse-core/computed/trace-of-tab');
+const TraceOfTab = require('lighthouse/lighthouse-core/computed/trace-of-tab.js');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {computeAdRequestWaterfall} = require('../utils/graph');

--- a/lighthouse-plugin-publisher-ads/audits/loads-ad-tag-over-https.js
+++ b/lighthouse-plugin-publisher-ads/audits/loads-ad-tag-over-https.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
+const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {isAdTag} = require('../utils/resource-classification');

--- a/lighthouse-plugin-publisher-ads/audits/loads-gpt-from-official-source.js
+++ b/lighthouse-plugin-publisher-ads/audits/loads-gpt-from-official-source.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
+const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {isGptTag} = require('../utils/resource-classification');

--- a/lighthouse-plugin-publisher-ads/audits/script-injected-tags.js
+++ b/lighthouse-plugin-publisher-ads/audits/script-injected-tags.js
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 const array = require('../utils/array.js');
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
-const PageDependencyGraph = require('lighthouse/lighthouse-core/computed/page-dependency-graph');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
+const PageDependencyGraph = require('lighthouse/lighthouse-core/computed/page-dependency-graph.js');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {computeAdRequestWaterfall} = require('../utils/graph');

--- a/lighthouse-plugin-publisher-ads/audits/serial-header-bidding.js
+++ b/lighthouse-plugin-publisher-ads/audits/serial-header-bidding.js
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 const ComputedAdRequestTime = require('../computed/ad-request-time');
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
 // @ts-ignore
-const MainResource = require('lighthouse/lighthouse-core/computed/main-resource');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
+const MainResource = require('lighthouse/lighthouse-core/computed/main-resource.js');
+const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {bucket} = require('../utils/array');

--- a/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
+++ b/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 const ComputedTagLoadTime = require('../computed/tag-load-time');
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
 const {auditNotApplicable, runWarning} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 

--- a/lighthouse-plugin-publisher-ads/audits/total-ad-blocking-time.js
+++ b/lighthouse-plugin-publisher-ads/audits/total-ad-blocking-time.js
@@ -8,9 +8,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
 const LongTasks = require('../computed/long-tasks');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
+const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {getAttributableUrl} = require('../utils/tasks');

--- a/lighthouse-plugin-publisher-ads/audits/viewport-ad-density.js
+++ b/lighthouse-plugin-publisher-ads/audits/viewport-ad-density.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
 const {auditNotApplicable, auditError} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {isAdIframe} = require('../utils/resource-classification');

--- a/lighthouse-plugin-publisher-ads/computed/ad-lantern-metric.js
+++ b/lighthouse-plugin-publisher-ads/computed/ad-lantern-metric.js
@@ -16,7 +16,7 @@ const BaseNode = require('lighthouse/lighthouse-core/lib/dependency-graph/base-n
 // eslint-disable-next-line no-unused-vars
 const CpuNode = require('lighthouse/lighthouse-core/lib/dependency-graph/cpu-node.js');
 // @ts-ignore Remove request() below after importing the type.
-const LanternMetric = require('lighthouse/lighthouse-core/computed/metrics/lantern-metric');
+const LanternMetric = require('lighthouse/lighthouse-core/computed/metrics/lantern-metric.js');
 // eslint-disable-next-line no-unused-vars
 const NetworkNode = require('lighthouse/lighthouse-core/lib/dependency-graph/network-node.js');
 const {isBidRelatedRequest, isImpressionPing, isGoogleAds, isGptAdRequest, isGptTag, isGptImplTag, toURL} = require('../utils/resource-classification');

--- a/lighthouse-plugin-publisher-ads/computed/ad-render-time.js
+++ b/lighthouse-plugin-publisher-ads/computed/ad-render-time.js
@@ -14,9 +14,9 @@
 
 const AdLanternMetric = require('./ad-lantern-metric');
 // @ts-ignore
-const ComputedMetric = require('lighthouse/lighthouse-core/computed/metrics/metric');
+const ComputedMetric = require('lighthouse/lighthouse-core/computed/metrics/metric.js');
 // @ts-ignore
-const makeComputedArtifact = require('lighthouse/lighthouse-core/computed/computed-artifact');
+const makeComputedArtifact = require('lighthouse/lighthouse-core/computed/computed-artifact.js');
 const {getPageStartTime, getImpressionStartTime} = require('../utils/network-timing');
 const {isImpressionPing} = require('../utils/resource-classification');
 

--- a/lighthouse-plugin-publisher-ads/computed/ad-request-time.js
+++ b/lighthouse-plugin-publisher-ads/computed/ad-request-time.js
@@ -14,9 +14,9 @@
 
 const AdLanternMetric = require('./ad-lantern-metric');
 // @ts-ignore
-const ComputedMetric = require('lighthouse/lighthouse-core/computed/metrics/metric');
+const ComputedMetric = require('lighthouse/lighthouse-core/computed/metrics/metric.js');
 // @ts-ignore
-const makeComputedArtifact = require('lighthouse/lighthouse-core/computed/computed-artifact');
+const makeComputedArtifact = require('lighthouse/lighthouse-core/computed/computed-artifact.js');
 const {getAdStartTime, getPageStartTime} = require('../utils/network-timing');
 const {isAdRequest} = require('../utils/resource-classification');
 

--- a/lighthouse-plugin-publisher-ads/computed/bid-request-time.js
+++ b/lighthouse-plugin-publisher-ads/computed/bid-request-time.js
@@ -14,9 +14,9 @@
 
 const AdLanternMetric = require('./ad-lantern-metric');
 // @ts-ignore
-const ComputedMetric = require('lighthouse/lighthouse-core/computed/metrics/metric');
+const ComputedMetric = require('lighthouse/lighthouse-core/computed/metrics/metric.js');
 // @ts-ignore
-const makeComputedArtifact = require('lighthouse/lighthouse-core/computed/computed-artifact');
+const makeComputedArtifact = require('lighthouse/lighthouse-core/computed/computed-artifact.js');
 const {getAdStartTime, getBidStartTime, getPageStartTime} = require('../utils/network-timing');
 const {isAdRequest, isBidRequest} = require('../utils/resource-classification');
 

--- a/lighthouse-plugin-publisher-ads/computed/long-tasks.js
+++ b/lighthouse-plugin-publisher-ads/computed/long-tasks.js
@@ -15,19 +15,19 @@
 const AdLanternMetric = require('../computed/ad-lantern-metric');
 const BaseNode = require('lighthouse/lighthouse-core/lib/dependency-graph/base-node.js');
 // @ts-ignore
-const ComputedMetric = require('lighthouse/lighthouse-core/computed/metrics/metric');
+const ComputedMetric = require('lighthouse/lighthouse-core/computed/metrics/metric.js');
 // eslint-disable-next-line no-unused-vars
 const CpuNode = require('lighthouse/lighthouse-core/lib/dependency-graph/cpu-node.js');
 const {getAttributableUrl} = require('../utils/tasks');
 // @ts-ignore
-const LoadSimulator = require('lighthouse/lighthouse-core/computed/load-simulator');
-const MainThreadTasks = require('lighthouse/lighthouse-core/computed/main-thread-tasks');
+const LoadSimulator = require('lighthouse/lighthouse-core/computed/load-simulator.js');
+const MainThreadTasks = require('lighthouse/lighthouse-core/computed/main-thread-tasks.js');
 // @ts-ignore
-const makeComputedArtifact = require('lighthouse/lighthouse-core/computed/computed-artifact');
+const makeComputedArtifact = require('lighthouse/lighthouse-core/computed/computed-artifact.js');
 // eslint-disable-next-line no-unused-vars
 const NetworkNode = require('lighthouse/lighthouse-core/lib/dependency-graph/network-node.js');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
-const PageDependencyGraph = require('lighthouse/lighthouse-core/computed/page-dependency-graph');
+const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
+const PageDependencyGraph = require('lighthouse/lighthouse-core/computed/page-dependency-graph.js');
 
 const PROVIDED_LONG_TASK_THRESHOLD_MS = 50;
 const SIMULATED_LONG_TASK_THRESHOLD_MS = 100;

--- a/lighthouse-plugin-publisher-ads/computed/tag-load-time.js
+++ b/lighthouse-plugin-publisher-ads/computed/tag-load-time.js
@@ -14,9 +14,9 @@
 
 const AdLanternMetric = require('./ad-lantern-metric');
 // @ts-ignore
-const ComputedMetric = require('lighthouse/lighthouse-core/computed/metrics/metric');
+const ComputedMetric = require('lighthouse/lighthouse-core/computed/metrics/metric.js');
 // @ts-ignore
-const makeComputedArtifact = require('lighthouse/lighthouse-core/computed/computed-artifact');
+const makeComputedArtifact = require('lighthouse/lighthouse-core/computed/computed-artifact.js');
 const {getPageStartTime, getTagEndTime} = require('../utils/network-timing');
 const {isImplTag} = require('../utils/resource-classification');
 const {URL} = require('url');

--- a/lighthouse-plugin-publisher-ads/messages/common-strings.js
+++ b/lighthouse-plugin-publisher-ads/messages/common-strings.js
@@ -41,7 +41,7 @@ const UIStrings = {
   WARNINGS__NO_AD_RENDERED: 'No ads were rendered when rendering this page.',
   WARNINGS__NO_TAG: 'The GPT tag was not requested.',
 };
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 

--- a/lighthouse-plugin-publisher-ads/plugin.js
+++ b/lighthouse-plugin-publisher-ads/plugin.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n');
+const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
 const {group} = require('./messages/common-strings');
 
 const PLUGIN_PATH = 'lighthouse-plugin-publisher-ads';

--- a/lighthouse-plugin-publisher-ads/test/audits/async-ad-tags_test.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/async-ad-tags_test.js
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 const AsyncAdTags = require('../../audits/async-ad-tags');
-const MainResource = require('lighthouse/lighthouse-core/computed/main-resource');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
+const MainResource = require('lighthouse/lighthouse-core/computed/main-resource.js');
+const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
 const sinon = require('sinon');
 const {expect} = require('chai');
 

--- a/lighthouse-plugin-publisher-ads/test/audits/full-width-slots_test.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/full-width-slots_test.js
@@ -15,7 +15,7 @@
 const chai = require('chai');
 const FullWidthSlots = require('../../audits/full-width-slots');
 const expect = chai.expect;
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
+const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
 const sinon = require('sinon');
 
 describe('FullWidthSlots', async () => {

--- a/lighthouse-plugin-publisher-ads/test/audits/loads-ad-tag-over-https_test.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/loads-ad-tag-over-https_test.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 const LoadsAdTagOverHttps = require('../../audits/loads-ad-tag-over-https');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
+const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
 const sinon = require('sinon');
 const {expect} = require('chai');
 

--- a/lighthouse-plugin-publisher-ads/typings/lighthouse.d.ts
+++ b/lighthouse-plugin-publisher-ads/typings/lighthouse.d.ts
@@ -80,18 +80,18 @@ declare module 'lighthouse-logger' {
   }
 }
 
-declare module 'lighthouse/lighthouse-core/computed/network-records' {
+declare module 'lighthouse/lighthouse-core/computed/network-records.js' {
   export function request(devToolsLog: LH.DevtoolsLog, context: LH.Audit.Context): Promise<Array<LH.Artifacts.NetworkRequest>>;
 }
 
-declare module 'lighthouse/lighthouse-core/computed/page-dependency-graph' {
+declare module 'lighthouse/lighthouse-core/computed/page-dependency-graph.js' {
   export function getNetworkInitiators(record: LH.Artifacts.NetworkRequest): Array<string>;
 }
 
-declare module 'lighthouse/lighthouse-core/computed/main-thread-tasks' {
+declare module 'lighthouse/lighthouse-core/computed/main-thread-tasks.js' {
   export function request(trace: LH.Trace, context: LH.Audit.Context): Promise<Array<TaskNode>>;
 }
 
-declare module 'lighthouse/lighthouse-core/lib/i18n/i18n'; {
+declare module 'lighthouse/lighthouse-core/lib/i18n/i18n.js'; {
   export function createMessageInstanceIdFn(filename: string, fileStrings: Record<string, string>);
 }

--- a/lighthouse-plugin-publisher-ads/utils/graph.js
+++ b/lighthouse-plugin-publisher-ads/utils/graph.js
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const BaseNode = require('lighthouse/lighthouse-core/lib/dependency-graph/base-node');
+const BaseNode = require('lighthouse/lighthouse-core/lib/dependency-graph/base-node.js');
 // eslint-disable-next-line no-unused-vars
 const CpuNode = require('lighthouse/lighthouse-core/lib/dependency-graph/cpu-node.js');
 // eslint-disable-next-line no-unused-vars
 const NetworkNode = require('lighthouse/lighthouse-core/lib/dependency-graph/network-node.js');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
+const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
 const {assert} = require('./asserts');
 const {getNameOrTld, trimUrl} = require('../utils/resource-classification');
-const {getNetworkInitiators} = require('lighthouse/lighthouse-core/computed/page-dependency-graph');
+const {getNetworkInitiators} = require('lighthouse/lighthouse-core/computed/page-dependency-graph.js');
 const {getTimingsByRecord} = require('../utils/network-timing');
 const {isAdRequest, isAdSense, isGpt, isBidRequest, isAdRelated} = require('./resource-classification');
 

--- a/lighthouse-plugin-publisher-ads/utils/network-timing.js
+++ b/lighthouse-plugin-publisher-ads/utils/network-timing.js
@@ -14,9 +14,9 @@
 
 const AdLanternMetric = require('../computed/ad-lantern-metric');
 // @ts-ignore
-const LoadSimulator = require('lighthouse/lighthouse-core/computed/load-simulator');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
-const PageDependencyGraph = require('lighthouse/lighthouse-core/computed/page-dependency-graph');
+const LoadSimulator = require('lighthouse/lighthouse-core/computed/load-simulator.js');
+const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
+const PageDependencyGraph = require('lighthouse/lighthouse-core/computed/page-dependency-graph.js');
 const {isAdRequest, isBidRequest, isImplTag, isImpressionPing} = require('./resource-classification');
 const {URL} = require('url');
 

--- a/lighthouse-plugin-publisher-ads/utils/network.js
+++ b/lighthouse-plugin-publisher-ads/utils/network.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // @ts-ignore
-const CacheHeaders = require('lighthouse/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl');
+const CacheHeaders = require('lighthouse/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js');
 // @ts-ignore
 const {parse: parseCacheControl} = require('@tusbar/cache-control');
 

--- a/lighthouse-plugin-publisher-ads/utils/resource-classification.js
+++ b/lighthouse-plugin-publisher-ads/utils/resource-classification.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 const bidderPatterns = require('./bidder-patterns');
-const thirdPartyWeb = require('lighthouse/lighthouse-core/lib/third-party-web');
+const thirdPartyWeb = require('lighthouse/lighthouse-core/lib/third-party-web.js');
 const {isCacheable} = require('../utils/network');
 const {URL} = require('url');
 


### PR DESCRIPTION
Before lighthouse can use the new `exports` feature of `package.json`, we need to fix some imports here. Specifying the extension is considered a best practice for a few reasons:

1) the node module resolution algorithm is pretty complex, and optional extensions are part of the reason why
2) ES modules running in browsers don't necessarily require an extension, but imports won't be rewritten to try with an implied js extension (the browser will only request of the server exactly the import string). Technically one could leave out extensions and configure a server to resolve files correctly / serve JS files without an extension, but obviously no one does that. So browser code is always going to have imports ending with `.js`. All that to say, the consistency is nice across JS environments.