### PR TITLE
use global URL instead of node url module

### DIFF
--- a/lighthouse-plugin-publisher-ads/audits/ad-blocking-tasks.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-blocking-tasks.js
@@ -14,7 +14,6 @@ const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {getAttributableUrl} = require('../utils/tasks');
 const {isAdScript} = require('../utils/resource-classification');
-const {URL} = require('url');
 
 const UIStrings = {
   /* Title of the audit */

--- a/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
@@ -19,7 +19,6 @@ const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {getTimingsByRecord} = require('../utils/network-timing');
 const {isAdTag} = require('../utils/resource-classification');
-const {URL} = require('url');
 
 const UIStrings = {
   title: 'Minimal render-blocking resources found',

--- a/lighthouse-plugin-publisher-ads/audits/async-ad-tags.js
+++ b/lighthouse-plugin-publisher-ads/audits/async-ad-tags.js
@@ -20,7 +20,6 @@ const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-reco
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {isAdTag, isStaticRequest} = require('../utils/resource-classification');
-const {URL} = require('url');
 
 const UIStrings = {
   title: 'Ad tag is loaded asynchronously',

--- a/lighthouse-plugin-publisher-ads/audits/duplicate-tags.js
+++ b/lighthouse-plugin-publisher-ads/audits/duplicate-tags.js
@@ -20,7 +20,6 @@ const NetworkRequest = require('lighthouse/lighthouse-core/lib/network-request.j
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {containsAnySubstring} = require('../utils/resource-classification');
-const {URL} = require('url');
 
 const UIStrings = {
   title: 'No duplicate tags found',

--- a/lighthouse-plugin-publisher-ads/audits/full-width-slots.js
+++ b/lighthouse-plugin-publisher-ads/audits/full-width-slots.js
@@ -17,7 +17,6 @@ const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-reco
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {isAdRequest} = require('../utils/resource-classification');
-const {URL} = require('url');
 
 const UIStrings = {
   title: 'Ad slots effectively use horizontal space',

--- a/lighthouse-plugin-publisher-ads/audits/loads-ad-tag-over-https.js
+++ b/lighthouse-plugin-publisher-ads/audits/loads-ad-tag-over-https.js
@@ -17,8 +17,6 @@ const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-reco
 const {auditNotApplicable} = require('../messages/common-strings');
 const {Audit} = require('lighthouse');
 const {isAdTag} = require('../utils/resource-classification');
-const {URL} = require('url');
-
 const UIStrings = {
   title: 'Ad tag is loaded over HTTPS',
   failureTitle: 'Load ad tag over HTTPS',

--- a/lighthouse-plugin-publisher-ads/audits/serial-header-bidding.js
+++ b/lighthouse-plugin-publisher-ads/audits/serial-header-bidding.js
@@ -23,7 +23,6 @@ const {bucket} = require('../utils/array');
 const {getTimingsByRecord} = require('../utils/network-timing');
 const {isCacheable} = require('../utils/network');
 const {isGoogleAds, getHeaderBidder} = require('../utils/resource-classification');
-const {URL} = require('url');
 
 /** @typedef {LH.Artifacts.NetworkRequest} NetworkRequest */
 /** @typedef {LH.Gatherer.Simulation.NodeTiming} NodeTiming */

--- a/lighthouse-plugin-publisher-ads/computed/tag-load-time.js
+++ b/lighthouse-plugin-publisher-ads/computed/tag-load-time.js
@@ -19,7 +19,6 @@ const ComputedMetric = require('lighthouse/lighthouse-core/computed/metrics/metr
 const makeComputedArtifact = require('lighthouse/lighthouse-core/computed/computed-artifact.js');
 const {getPageStartTime, getTagEndTime} = require('../utils/network-timing');
 const {isImplTag} = require('../utils/resource-classification');
-const {URL} = require('url');
 
 // @ts-ignore
 // eslint-disable-next-line max-len

--- a/lighthouse-plugin-publisher-ads/test/utils/array_test.js
+++ b/lighthouse-plugin-publisher-ads/test/utils/array_test.js
@@ -15,7 +15,6 @@
 const array = require('../../utils/array');
 const {expect} = require('chai');
 const {isGoogleAds} = require('../../utils/resource-classification');
-const {URL} = require('url');
 
 describe('array', () => {
   describe('#count', () => {

--- a/lighthouse-plugin-publisher-ads/test/utils/resource-classification_test.js
+++ b/lighthouse-plugin-publisher-ads/test/utils/resource-classification_test.js
@@ -14,7 +14,6 @@
 
 const {expect} = require('chai');
 const {isGoogleAds, isGptAdRequest, isImpressionPing, isGptTag, isGptImplTag, isAMPTag, isAMPAdRequest} = require('../../utils/resource-classification');
-const {URL} = require('url');
 
 describe('resource-classification', () => {
   describe('#isGoogleAds', () => {

--- a/lighthouse-plugin-publisher-ads/utils/network-timing.js
+++ b/lighthouse-plugin-publisher-ads/utils/network-timing.js
@@ -18,7 +18,6 @@ const LoadSimulator = require('lighthouse/lighthouse-core/computed/load-simulato
 const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
 const PageDependencyGraph = require('lighthouse/lighthouse-core/computed/page-dependency-graph.js');
 const {isAdRequest, isBidRequest, isImplTag, isImpressionPing} = require('./resource-classification');
-const {URL} = require('url');
 
 /** @typedef {LH.Artifacts.NetworkRequest} NetworkRequest */
 /** @typedef {LH.Gatherer.Simulation.NodeTiming} NodeTiming */

--- a/lighthouse-plugin-publisher-ads/utils/resource-classification.js
+++ b/lighthouse-plugin-publisher-ads/utils/resource-classification.js
@@ -15,7 +15,6 @@
 const bidderPatterns = require('./bidder-patterns');
 const thirdPartyWeb = require('lighthouse/lighthouse-core/lib/third-party-web.js');
 const {isCacheable} = require('../utils/network');
-const {URL} = require('url');
 
 /**
  * Converts the given url to a URL, if it's not already a URL. Otherwise returns


### PR DESCRIPTION
Node 10 added a global [`URL`](https://nodejs.org/api/globals.html#globals_url). The alias under `require('url').URL` is completely equivalent, except for some reason all the Node URL polyfills don't seem to bother to add `URL` to the '`url'` module and so it doesn't work automatically when bundled (using the default browserify and rollup polyfills, at least).

This has always worked anyways in Lighthouse because the library `robots-parser` gets `URL` the same way and so it's had to be manually patched, but the way we did it was kind of a hack. We have to change how we patch it in Lighthouse so I was trying to remember why we did it this hacky way (goes back to https://github.com/GoogleChrome/lighthouse/pull/5293) and realized pubads also needed it.

This PR isn't pressing because we still need to get it changed in `robots-parser` and it's still a pretty trivial workaround in the meantime, but since URL has been a global for so long, it seems as good a time as any to start backing out the need for a polyfill or patch.