### PR TITLE
Fix long execution times caused by isAdRelated

### DIFF
--- a/lighthouse-plugin-publisher-ads/test/utils/resource-classification_test.js
+++ b/lighthouse-plugin-publisher-ads/test/utils/resource-classification_test.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 const {expect} = require('chai');
-const {isGoogleAds, isGptAdRequest, isImpressionPing, isGptTag, isGptImplTag, isAMPTag, isAMPAdRequest} = require('../../utils/resource-classification');
+const {isGoogleAds, isGptAdRequest, isImpressionPing, isGptTag, isGptImplTag, isAMPTag, isAMPAdRequest, isAdRelated} = require('../../utils/resource-classification');
 
 describe('resource-classification', () => {
   describe('#isGoogleAds', () => {
@@ -271,6 +271,65 @@ describe('resource-classification', () => {
     for (const {description, url, expectation} of testCases) {
       it(`should return ${expectation} for ${description}`, () => {
         const results = isAMPTag(url);
+        expect(results).to.equal(expectation);
+      });
+    }
+  });
+  describe('#isAdRelated', () => {
+    const testCases = [
+      {
+        description: 'undefined url property',
+        requestOrUrl: {},
+        expectation: false,
+      },
+      {
+        description: 'empty string url',
+        requestOrUrl: '',
+        expectation: false,
+      },
+      {
+        description: 'empty string url property',
+        requestOrUrl: {
+          url: '',
+        },
+        expectation: false,
+      },
+      {
+        description: 'ad script url passed as the url property',
+        requestOrUrl: {
+          url: 'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js',
+        },
+        expectation: true,
+      },
+      {
+        description: 'ad script url',
+        requestOrUrl: 'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js',
+        expectation: true,
+      },
+      {
+        description: 'header bidder url',
+        requestOrUrl: 'https://acdn.adnxs.com/prebid/foo.js',
+        expectation: true,
+      },
+      {
+        description: 'url that is a known third party in the ad category',
+        requestOrUrl: 'https://t.mookie1.com/foo.js',
+        expectation: true,
+      },
+      {
+        description: 'url that is a known third party, but not in the ad category',
+        requestOrUrl: 'https://beacon-v2.helpscout.net/',
+        expectation: false,
+      },
+      {
+        description: 'url that is not an ad script, header bidder, or known third party',
+        requestOrUrl: 'https://foo.com',
+        expectation: false,
+      },
+    ];
+    for (const {description, requestOrUrl, expectation} of testCases) {
+      it(`should return ${expectation} for ${description}`, () => {
+        const results = isAdRelated(requestOrUrl);
         expect(results).to.equal(expectation);
       });
     }

--- a/lighthouse-plugin-publisher-ads/utils/resource-classification.js
+++ b/lighthouse-plugin-publisher-ads/utils/resource-classification.js
@@ -402,6 +402,11 @@ function getNameOrTld(url) {
  */
 function isAdRelated(requestOrUrl) {
   const url = typeof requestOrUrl == 'string' ? requestOrUrl : requestOrUrl.url;
+
+  if (!url) {
+    return false;
+  }
+
   if (isAdScript(url) || getHeaderBidder(url)) {
     return true;
   }


### PR DESCRIPTION
## Problem

Running Lighthouse tests with the `publisher-ads-lighthouse-plugin` increases runtime significantly.

Via the CLI on an M1 MacBook Pro, the following increase in runtime was observed for the following sites

* https://www.cnn.com - 8s
* https://www.wired.com - 6s
* https://google.com - 942ms

There is a relationship between the number of resources loaded on a page and the increase in execution time.

This issue was initially detected when adding the plugin to a suite of tests evaluating ~160 different domains. Average Lighthouse run time increased from 20s to 34s.

## Reproduction Steps

- Environment (CLI or web service): cli and node package
- Version: 1.5.5, Lighthouse 9.2.0 and 9.3.1 
- URL: https://www.cnn.com
- Settings: n/a

To reproduce:

1. Run 

    ```
    lighthouse https://www.cnn.com --plugins=lighthouse-plugin-publisher-ads --chrome-flags="--headless"
    ...
    LH:status Auditing: Cumulative ad shift +2ms
    LH:status Auditing: Deprecated GPT API Usage +8s
    LH:status Auditing: GPT Errors +1ms
    LH:status Auditing: Total ad JS blocking time +1ms
    LH:status Generating results... +2ms
    ```
1. Note the `8s` time attributed (incorrectly) to `Auditing: Deprecated GPT API Usage`

## Solution

Through profiling and manually removing audits, the audit causing this issue is "Cumulative ad shift", not "Deprecated GPT API Usage" as the output suggests. To demonstrate this, comment out the following two lines in `plugin.js` and run the reproduction steps above:

```
{path: `${PLUGIN_PATH}/audits/cumulative-ad-shift`},

{id: 'cumulative-ad-shift', weight: 5, group: 'metrics'},
```

The performance issue will disappear, implicating the "Cumulative ad shift" audit as the source of the problem.

Generating a flame chart using `clinic` will clearly show the issue:

```
npx clinic flame -- node $(which lighthouse) https://www.cnn.com --plugins=lighthouse-plugin-publisher-ads --chrome-flags="--headless"
```

<img width="1797" alt="Screen Shot 2022-02-16 at 9 29 20 PM" src="https://user-images.githubusercontent.com/921795/154401146-94d5eb52-bec4-4c64-8047-5c01bffaa120.png">

The function taking a lot of time is `onParseError` from Node. This function is called when `toURL` receives an `undefined` value. In the `try` statement, the value is passed to `new URL()` and throws. Apparently, parsing and throwing this error is expensive.

In my testing, I console logged `url` in `toURL` and found that it is `undefined` up to ~1 million times when testing a site that loads a lot (e.g., 500) of resources.

The function's comment states:

```
This function is guaranteed not to throw. Be sure to validate URL format
before calling this method if needed.
```

As such, my fix in this PR is to validate the URL before it ever gets to `toURL` in `isAdRelated`. `isAdRelated` seems to be the root of the majority of the `toURL` calls. As such, this PR changes the function to return `false` whenever it receives falsey `url` value. If it's falsey, there is no way this is ad related so it makes sense that all of the other logic in this method can be skipped.

The fix in this PR reduces the runtime dramatically (8s to 104ms):

```
lighthouse https://www.cnn.com --plugins=lighthouse-plugin-publisher-ads --chrome-flags="--headless"
LH:status Auditing: Cumulative ad shift +1ms
LH:status Auditing: Deprecated GPT API Usage +104ms
LH:status Auditing: GPT Errors +1ms
LH:status Auditing: Total ad JS blocking time +1ms
LH:status Generating results... +1ms
```

Note that no tests were previously written for `isAdRelated`. This PR adds those tests and attempts to evaluate each branch. The tests pass before and after applying the patch, except for the tests of the undefined url that are handled with the patch.