### PR TITLE
Add supported modes to category

### DIFF
--- a/lighthouse-plugin-publisher-ads/plugin.js
+++ b/lighthouse-plugin-publisher-ads/plugin.js
@@ -65,6 +65,7 @@ module.exports = {
   category: {
     title: 'Publisher Ads',
     description: str_(UIStrings.categoryDescription),
+    supportedModes: ['navigation'],
     auditRefs: [
       // Measurements group.
       {id: 'tag-load-time', weight: 5, group: 'metrics'},


### PR DESCRIPTION
This change prevents the plugin from operating in "timespan" and "snapshot" modes which can be used to audit a page beyond the initial page load: https://github.com/GoogleChrome/lighthouse/blob/master/docs/user-flows.md. The "navigation" mode is how Lighthouse traditionally works.

Before this change, this plugin would emit errors in timespan mode because the trace does not always include events such as the FCP in timespan mode.

I think it's best to exclude the new modes for now to prevent errors from popping up in DevTools Lighthouse.