### PR TITLE
Update ads-in-viewport audit failure title

### DIFF
--- a/lighthouse-plugin-publisher-ads/audits/ads-in-viewport.js
+++ b/lighthouse-plugin-publisher-ads/audits/ads-in-viewport.js
@@ -21,7 +21,7 @@ const {isGptIframe} = require('../utils/resource-classification');
 
 const UIStrings = {
   title: 'Few or no ads loaded outside viewport',
-  failureTitle: 'Avoid loading ads until they are nearly on-screen',
+  failureTitle: 'Lazily load ads below the fold',
   description: 'Too many ads loaded outside the viewport lowers viewability ' +
   'rates and impacts user experience. Consider loading ads below the fold ' +
   'lazily as the user scrolls down. Consider using GPT\'s [Lazy Loading API](' +


### PR DESCRIPTION
Changing failure title from "Avoid loading ads until they are nearly on-screen" -> "Lazily load ads below the fold", to match the documentation changes from #346.