### PR TITLE
convert to ES modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - name: git clone
         uses: actions/checkout@v2
-      - name: Use Node.js 12.x
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 14.x
       - run: yarn install --frozen-lockfile --network-timeout 1000000
       - run: yarn lint
 
@@ -23,10 +23,10 @@ jobs:
     steps:
       - name: git clone
         uses: actions/checkout@v2
-      - name: Use Node.js 12.x
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 14.x
       - run: yarn install --frozen-lockfile --network-timeout 1000000
       - run: yarn type-check
 
@@ -36,10 +36,10 @@ jobs:
     steps:
       - name: git clone
         uses: actions/checkout@v2
-      - name: Use Node.js 12.x
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 14.x
       - run: yarn install --frozen-lockfile --network-timeout 1000000
       - run: yarn test
 
@@ -49,10 +49,10 @@ jobs:
     steps:
       - name: git clone
         uses: actions/checkout@v2
-      - name: Use Node.js 12.x
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 14.x
       - run: yarn install --frozen-lockfile --network-timeout 1000000
       - run: sudo apt-get install xvfb
       - name: Run smoke tests
@@ -64,10 +64,10 @@ jobs:
     steps:
       - name: git clone
         uses: actions/checkout@v2
-      - name: Use Node.js 12.x
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 14.x
       - name: npm install
         run: npm install
       - name: Install Lighthouse CI

--- a/config.js
+++ b/config.js
@@ -20,7 +20,7 @@
  * https://github.com/GoogleChrome/lighthouse/tree/master/lighthouse-core/config
  * @const {LH.Config}
  */
-module.exports = {
+const config = {
   extends: 'lighthouse:default',
   plugins: ['lighthouse-plugin-publisher-ads'],
   passes: [
@@ -29,3 +29,5 @@ module.exports = {
     },
   ],
 };
+
+export default config;

--- a/index.cjs
+++ b/index.cjs
@@ -39,7 +39,8 @@ async function main() {
   }
 
   // @ts-ignore let LH handle the CLI
-  await require('lighthouse/lighthouse-cli/bin.js').begin();
+  const {begin} = await import('lighthouse/lighthouse-cli/bin.js');
+  await begin();
 }
 
 if (require.main == module) {

--- a/lighthouse-plugin-publisher-ads/.eslintrc.cjs
+++ b/lighthouse-plugin-publisher-ads/.eslintrc.cjs
@@ -19,8 +19,13 @@ module.exports = {
     node: true,
     mocha: true,
   },
+  parser: '@typescript-eslint/parser',
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
+    ecmaFeatures: {
+      globalReturn: true,
+      jsx: false,
+    },
     sourceType: 'script',
   },
   rules: {
@@ -29,6 +34,7 @@ module.exports = {
       {'MemberExpression': 2},
     ],
     'max-len': ['error', 80, {
+      ignorePattern: '^import |/override',
       ignoreStrings: true,
       ignoreUrls: true,
     }],

--- a/lighthouse-plugin-publisher-ads/audits/ad-blocking-tasks.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-blocking-tasks.js
@@ -7,13 +7,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const AdRequestTime = require('../computed/ad-request-time');
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const LongTasks = require('../computed/long-tasks');
-const {auditNotApplicable} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
-const {getAttributableUrl} = require('../utils/tasks');
-const {isAdScript} = require('../utils/resource-classification');
+import AdRequestTime from '../computed/ad-request-time.js';
+
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+import LongTasks from '../computed/long-tasks.js';
+import {auditNotApplicable} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
+import {getAttributableUrl} from '../utils/tasks.js';
+import {isAdScript} from '../utils/resource-classification.js';
 
 const UIStrings = {
   /* Title of the audit */
@@ -31,7 +32,7 @@ const UIStrings = {
   columnDuration: 'Duration',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 /**
  * @typedef {Object} TaskDetails
  * @property {number} startTime
@@ -70,7 +71,7 @@ const HEADINGS = [
 class AdBlockingTasks extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -170,5 +171,5 @@ class AdBlockingTasks extends Audit {
   }
 }
 
-module.exports = AdBlockingTasks;
-module.exports.UIStrings = UIStrings;
+export default AdBlockingTasks;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/ad-blocking-tasks.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-blocking-tasks.js
@@ -71,7 +71,6 @@ const HEADINGS = [
 class AdBlockingTasks extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
@@ -12,13 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+
+import NetworkRecords from 'lighthouse/lighthouse-core/computed/network-records.js';
+
 // @ts-ignore
-const {auditNotApplicable} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
-const {getTimingsByRecord} = require('../utils/network-timing');
-const {isAdTag} = require('../utils/resource-classification');
+import {auditNotApplicable} from '../messages/common-strings.js';
+
+import {Audit} from 'lighthouse';
+import {getTimingsByRecord} from '../utils/network-timing.js';
+import {isAdTag} from '../utils/resource-classification.js';
 
 const UIStrings = {
   title: 'Minimal render-blocking resources found',
@@ -38,7 +41,7 @@ const UIStrings = {
 /** @typedef {LH.Artifacts.NetworkRequest} NetworkRequest */
 /** @typedef {LH.Gatherer.Simulation.NodeTiming} NodeTiming */
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 const THRESHOLD_MS = 100;
 
@@ -70,7 +73,7 @@ const HEADINGS = [
 class AdRenderBlockingResources extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -165,5 +168,5 @@ class AdRenderBlockingResources extends Audit {
   }
 }
 
-module.exports = AdRenderBlockingResources;
-module.exports.UIStrings = UIStrings;
+export default AdRenderBlockingResources;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-render-blocking-resources.js
@@ -73,7 +73,6 @@ const HEADINGS = [
 class AdRenderBlockingResources extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/ad-request-critical-path.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-critical-path.js
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const {auditNotApplicable} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
-const {computeAdRequestWaterfall} = require('../utils/graph');
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+
+import {auditNotApplicable} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
+import {computeAdRequestWaterfall} from '../utils/graph.js';
 
 /** @typedef {LH.Gatherer.Simulation.NodeTiming} NodeTiming */
-/** @typedef {import('../utils/graph').SimpleRequest} SimpleRequest */
+/** @typedef {import('../utils/graph.js').SimpleRequest} SimpleRequest */
 
 const UIStrings = {
   title: 'Ad request waterfall',
@@ -35,7 +36,7 @@ const UIStrings = {
   columnEndTime: 'End',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 /**
  * Table headings for audits details sections.
@@ -118,7 +119,7 @@ function computeIdleTimes(blockingRequests) {
 class AdRequestCriticalPath extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -173,5 +174,5 @@ class AdRequestCriticalPath extends Audit {
   }
 }
 
-module.exports = AdRequestCriticalPath;
-module.exports.UIStrings = UIStrings;
+export default AdRequestCriticalPath;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/ad-request-critical-path.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-critical-path.js
@@ -119,7 +119,6 @@ function computeIdleTimes(blockingRequests) {
 class AdRequestCriticalPath extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const ComputedAdRequestTime = require('../computed/ad-request-time');
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const {auditNotApplicable, runWarning} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
+import ComputedAdRequestTime from '../computed/ad-request-time.js';
+
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+import {auditNotApplicable, runWarning} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
 
 const UIStrings = {
   title: 'First ad request time',
@@ -29,7 +30,7 @@ const UIStrings = {
   displayValue: '{timeInMs, number, seconds} s',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 /**
  * Audit to determine time for first ad request relative to page start.
@@ -37,7 +38,7 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 class AdRequestFromPageStart extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -102,5 +103,5 @@ class AdRequestFromPageStart extends Audit {
   }
 }
 
-module.exports = AdRequestFromPageStart;
-module.exports.UIStrings = UIStrings;
+export default AdRequestFromPageStart;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-from-page-start.js
@@ -38,7 +38,6 @@ const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 class AdRequestFromPageStart extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/ad-request-from-tag-load.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-from-tag-load.js
@@ -37,7 +37,6 @@ const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 class AdRequestFromTagLoad extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/ad-request-from-tag-load.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-request-from-tag-load.js
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const ComputedAdRequestTime = require('../computed/ad-request-time');
-const ComputedTagLoadTime = require('../computed/tag-load-time');
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const {auditNotApplicable} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
+import ComputedAdRequestTime from '../computed/ad-request-time.js';
+
+import ComputedTagLoadTime from '../computed/tag-load-time.js';
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+import {auditNotApplicable} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
 
 const UIStrings = {
   title: 'Latency of first ad request, from tag load',
@@ -28,7 +29,7 @@ const UIStrings = {
   displayValue: '{timeInMs, number, seconds} s',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 /**
  * Audit to determine time for first ad request relative to tag load.
@@ -36,7 +37,7 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 class AdRequestFromTagLoad extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -105,5 +106,5 @@ class AdRequestFromTagLoad extends Audit {
   }
 }
 
-module.exports = AdRequestFromTagLoad;
-module.exports.UIStrings = UIStrings;
+export default AdRequestFromTagLoad;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/ad-top-of-viewport.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-top-of-viewport.js
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const {auditNotApplicable} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
-const {isAdIframe} = require('../utils/resource-classification');
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+
+import {auditNotApplicable} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
+import {isAdIframe} from '../utils/resource-classification.js';
 
 const UIStrings = {
   title: 'No ad found at the very top of the viewport',
@@ -30,7 +31,7 @@ const UIStrings = {
   columnSlot: 'Top Slot ID',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 
 const SCROLL_PX_THRESHOLD = 100;
@@ -48,7 +49,7 @@ const HEADINGS = [
 class AdTopOfViewport extends Audit {
   /**
    * @return {AuditMetadata}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -105,5 +106,5 @@ class AdTopOfViewport extends Audit {
   }
 }
 
-module.exports = AdTopOfViewport;
-module.exports.UIStrings = UIStrings;
+export default AdTopOfViewport;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/ad-top-of-viewport.js
+++ b/lighthouse-plugin-publisher-ads/audits/ad-top-of-viewport.js
@@ -49,7 +49,6 @@ const HEADINGS = [
 class AdTopOfViewport extends Audit {
   /**
    * @return {AuditMetadata}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/ads-in-viewport.js
+++ b/lighthouse-plugin-publisher-ads/audits/ads-in-viewport.js
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const {auditNotApplicable} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
+import {auditNotApplicable} from '../messages/common-strings.js';
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const {isBoxInViewport} = require('../utils/geometry');
-const {isGptIframe} = require('../utils/resource-classification');
+import {Audit} from 'lighthouse';
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+import {isBoxInViewport} from '../utils/geometry.js';
+import {isGptIframe} from '../utils/resource-classification.js';
 
 const UIStrings = {
   title: 'Few or no ads loaded outside viewport',
@@ -34,7 +34,7 @@ const UIStrings = {
   columnSlot: 'Slots Outside Viewport',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 /**
  * Table headings for audits details sections.
@@ -48,7 +48,7 @@ const HEADINGS = [
 class AdsInViewport extends Audit {
   /**
    * @return {AuditMetadata}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -94,5 +94,5 @@ class AdsInViewport extends Audit {
   }
 }
 
-module.exports = AdsInViewport;
-module.exports.UIStrings = UIStrings;
+export default AdsInViewport;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/ads-in-viewport.js
+++ b/lighthouse-plugin-publisher-ads/audits/ads-in-viewport.js
@@ -48,7 +48,6 @@ const HEADINGS = [
 class AdsInViewport extends Audit {
   /**
    * @return {AuditMetadata}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/async-ad-tags.js
+++ b/lighthouse-plugin-publisher-ads/audits/async-ad-tags.js
@@ -12,14 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const array = require('../utils/array.js');
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
+import * as array from '../utils/array.js';
+
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+
 // @ts-ignore
-const MainResource = require('lighthouse/lighthouse-core/computed/main-resource.js');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
-const {auditNotApplicable} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
-const {isAdTag, isStaticRequest} = require('../utils/resource-classification');
+import MainResource from 'lighthouse/lighthouse-core/computed/main-resource.js';
+
+import NetworkRecords from 'lighthouse/lighthouse-core/computed/network-records.js';
+import {auditNotApplicable} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
+import {isAdTag, isStaticRequest} from '../utils/resource-classification.js';
 
 const UIStrings = {
   title: 'Ad tag is loaded asynchronously',
@@ -31,7 +34,7 @@ const UIStrings = {
   ').',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 /**
  * @param {LH.Artifacts.NetworkRequest} tagReq
  * @return {boolean}
@@ -48,7 +51,7 @@ function isAsync(tagReq) {
 class AsyncAdTags extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -88,5 +91,5 @@ class AsyncAdTags extends Audit {
   }
 }
 
-module.exports = AsyncAdTags;
-module.exports.UIStrings = UIStrings;
+export default AsyncAdTags;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/async-ad-tags.js
+++ b/lighthouse-plugin-publisher-ads/audits/async-ad-tags.js
@@ -51,7 +51,6 @@ function isAsync(tagReq) {
 class AsyncAdTags extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/bid-request-from-page-start.js
+++ b/lighthouse-plugin-publisher-ads/audits/bid-request-from-page-start.js
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const ComputedBidRequestTime = require('../computed/bid-request-time');
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const {auditNotApplicable} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
+import ComputedBidRequestTime from '../computed/bid-request-time.js';
+
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+import {auditNotApplicable} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
 
 const UIStrings = {
   title: 'First bid request time',
@@ -29,7 +30,7 @@ const UIStrings = {
   displayValue: '{timeInMs, number, seconds} s',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 /**
  * Audit to determine time for first ad request relative to page start.
@@ -37,7 +38,7 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 class BidRequestFromPageStart extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -101,5 +102,5 @@ class BidRequestFromPageStart extends Audit {
   }
 }
 
-module.exports = BidRequestFromPageStart;
-module.exports.UIStrings = UIStrings;
+export default BidRequestFromPageStart;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/bid-request-from-page-start.js
+++ b/lighthouse-plugin-publisher-ads/audits/bid-request-from-page-start.js
@@ -38,7 +38,6 @@ const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 class BidRequestFromPageStart extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/blocking-load-events.js
+++ b/lighthouse-plugin-publisher-ads/audits/blocking-load-events.js
@@ -12,16 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+
+import NetworkRecords from 'lighthouse/lighthouse-core/computed/network-records.js';
+
 // @ts-expect-error
-const ProcessedTrace = require('lighthouse/lighthouse-core/computed/processed-trace.js');
+import ProcessedTrace from 'lighthouse/lighthouse-core/computed/processed-trace.js';
+
 // @ts-expect-error
-const ProcessedNavigation = require('lighthouse/lighthouse-core/computed/processed-navigation.js');
-const {auditNotApplicable} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
-const {computeAdRequestWaterfall} = require('../utils/graph');
-const {getTimingsByRecord} = require('../utils/network-timing');
+import ProcessedNavigation from 'lighthouse/lighthouse-core/computed/processed-navigation.js';
+
+import {auditNotApplicable} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
+import {computeAdRequestWaterfall} from '../utils/graph.js';
+import {getTimingsByRecord} from '../utils/network-timing.js';
 
 /** @typedef {LH.Artifacts.NetworkRequest} NetworkRequest */
 /** @typedef {LH.Gatherer.Simulation.NodeTiming} NodeTiming */
@@ -42,7 +46,7 @@ const UIStrings = {
   columnFunctionName: 'Function',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 /**
  * Table headings for audits details sections.
@@ -55,7 +59,7 @@ const HEADINGS = [
   {key: 'functionName', itemType: 'text', text: str_(UIStrings.columnFunctionName)},
 ];
 
-/** @typedef {import('../utils/graph').SimpleRequest} SimpleRequest */
+/** @typedef {import('../utils/graph.js').SimpleRequest} SimpleRequest */
 
 /**
  * @param {SimpleRequest} request
@@ -158,7 +162,7 @@ function quantifyBlockedTime(blockingEvent, networkRecords, timingsByRecord) {
 class BlockingLoadEvents extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -252,5 +256,5 @@ class BlockingLoadEvents extends Audit {
   }
 }
 
-module.exports = BlockingLoadEvents;
-module.exports.UIStrings = UIStrings;
+export default BlockingLoadEvents;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/blocking-load-events.js
+++ b/lighthouse-plugin-publisher-ads/audits/blocking-load-events.js
@@ -162,7 +162,6 @@ function quantifyBlockedTime(blockingEvent, networkRecords, timingsByRecord) {
 class BlockingLoadEvents extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/bottleneck-requests.js
+++ b/lighthouse-plugin-publisher-ads/audits/bottleneck-requests.js
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const {auditNotApplicable} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
-const {computeAdRequestWaterfall} = require('../utils/graph');
-const {isAdScript, toURL} = require('../utils/resource-classification');
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+
+import {auditNotApplicable} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
+import {computeAdRequestWaterfall} from '../utils/graph.js';
+import {isAdScript, toURL} from '../utils/resource-classification.js';
 
 /** @typedef {LH.Artifacts.NetworkRequest} NetworkRequest */
-/** @typedef {import('../utils/graph').SimpleRequest} SimpleRequest */
+/** @typedef {import('../utils/graph.js').SimpleRequest} SimpleRequest */
 
 const UIStrings = {
   title: 'No bottleneck requests found',
@@ -37,7 +38,7 @@ const UIStrings = {
   columnDuration: 'Total Time',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 
 /**
@@ -71,7 +72,7 @@ const HEADINGS = [
 class BottleneckRequests extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -131,5 +132,5 @@ class BottleneckRequests extends Audit {
   }
 }
 
-module.exports = BottleneckRequests;
-module.exports.UIStrings = UIStrings;
+export default BottleneckRequests;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/bottleneck-requests.js
+++ b/lighthouse-plugin-publisher-ads/audits/bottleneck-requests.js
@@ -72,7 +72,6 @@ const HEADINGS = [
 class BottleneckRequests extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
+++ b/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const {auditNotApplicable} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
-const {getScriptUrl} = require('../utils/network-timing');
-const {isAdIframe, isAdRelated, isImplTag} = require('../utils/resource-classification');
-const {overlaps, toClientRect} = require('../utils/geometry');
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+
+import {auditNotApplicable} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
+import {getScriptUrl} from '../utils/network-timing.js';
+import {isAdIframe, isAdRelated, isImplTag} from '../utils/resource-classification.js';
+import {overlaps, toClientRect} from '../utils/geometry.js';
 
 const UIStrings = {
   title: 'Cumulative ad shift',
@@ -29,7 +30,7 @@ const UIStrings = {
           '(https://developers.google.com/publisher-ads-audits/reference/audits/cumulative-ad-shift).',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 /**
  * Audit to determine time for first ad request relative to page start.
@@ -37,7 +38,7 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 class CumulativeAdShift extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -237,5 +238,5 @@ class CumulativeAdShift extends Audit {
   }
 }
 
-module.exports = CumulativeAdShift;
-module.exports.UIStrings = UIStrings;
+export default CumulativeAdShift;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
+++ b/lighthouse-plugin-publisher-ads/audits/cumulative-ad-shift.js
@@ -38,7 +38,6 @@ const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 class CumulativeAdShift extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/deprecated-api-usage.js
+++ b/lighthouse-plugin-publisher-ads/audits/deprecated-api-usage.js
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
-const {auditNotApplicable} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
-const {isGpt, isGptImplTag} = require('../utils/resource-classification');
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+
+import NetworkRecords from 'lighthouse/lighthouse-core/computed/network-records.js';
+import {auditNotApplicable} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
+import {isGpt, isGptImplTag} from '../utils/resource-classification.js';
 
 const UIStrings = {
   title: 'Deprecated GPT API Usage',
@@ -28,7 +29,7 @@ const UIStrings = {
   displayValue: '{numErrors, plural, =1 {1 error} other {# errors}} found',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 /**
  * Audit that checks for the presence of warning and error messages which
@@ -37,7 +38,7 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 class DeprecatedApiUsage extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -100,5 +101,5 @@ class DeprecatedApiUsage extends Audit {
   }
 }
 
-module.exports = DeprecatedApiUsage;
-module.exports.UIStrings = UIStrings;
+export default DeprecatedApiUsage;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/deprecated-api-usage.js
+++ b/lighthouse-plugin-publisher-ads/audits/deprecated-api-usage.js
@@ -38,7 +38,6 @@ const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 class DeprecatedApiUsage extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/duplicate-tags.js
+++ b/lighthouse-plugin-publisher-ads/audits/duplicate-tags.js
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+
 // @ts-ignore
-const MainResource = require('lighthouse/lighthouse-core/computed/main-resource.js');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
-const NetworkRequest = require('lighthouse/lighthouse-core/lib/network-request.js');
-const {auditNotApplicable} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
-const {containsAnySubstring} = require('../utils/resource-classification');
+import MainResource from 'lighthouse/lighthouse-core/computed/main-resource.js';
+
+import NetworkRecords from 'lighthouse/lighthouse-core/computed/network-records.js';
+import {NetworkRequest} from 'lighthouse/lighthouse-core/lib/network-request.js';
+import {auditNotApplicable} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
+import {containsAnySubstring} from '../utils/resource-classification.js';
 
 const UIStrings = {
   title: 'No duplicate tags found',
@@ -34,7 +36,7 @@ const UIStrings = {
   columnFrameId: 'Frame ID',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 const tags = [
   'googletagservices.com/tag/js/gpt.js',
@@ -59,7 +61,7 @@ const HEADINGS = [
 class DuplicateTags extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -117,5 +119,5 @@ class DuplicateTags extends Audit {
   }
 }
 
-module.exports = DuplicateTags;
-module.exports.UIStrings = UIStrings;
+export default DuplicateTags;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/duplicate-tags.js
+++ b/lighthouse-plugin-publisher-ads/audits/duplicate-tags.js
@@ -61,7 +61,6 @@ const HEADINGS = [
 class DuplicateTags extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/first-ad-render.js
+++ b/lighthouse-plugin-publisher-ads/audits/first-ad-render.js
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const ComputedAdRenderTime = require('../computed/ad-render-time');
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const {auditNotApplicable, runWarning} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
+import ComputedAdRenderTime from '../computed/ad-render-time.js';
+
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+import {auditNotApplicable, runWarning} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
 
 const UIStrings = {
   title: 'Latency of first ad render',
@@ -27,7 +28,7 @@ const UIStrings = {
   displayValue: '{timeInMs, number, seconds} s',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 /**
  * Measures the first ad render time.
@@ -35,7 +36,7 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 class FirstAdRender extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     // @ts-ignore
@@ -109,5 +110,5 @@ class FirstAdRender extends Audit {
     };
   }
 }
-module.exports = FirstAdRender;
-module.exports.UIStrings = UIStrings;
+export default FirstAdRender;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/first-ad-render.js
+++ b/lighthouse-plugin-publisher-ads/audits/first-ad-render.js
@@ -36,7 +36,6 @@ const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 class FirstAdRender extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     // @ts-ignore

--- a/lighthouse-plugin-publisher-ads/audits/full-width-slots.js
+++ b/lighthouse-plugin-publisher-ads/audits/full-width-slots.js
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
-const {auditNotApplicable} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
-const {isAdRequest} = require('../utils/resource-classification');
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+
+import NetworkRecords from 'lighthouse/lighthouse-core/computed/network-records.js';
+import {auditNotApplicable} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
+import {isAdRequest} from '../utils/resource-classification.js';
 
 const UIStrings = {
   title: 'Ad slots effectively use horizontal space',
@@ -29,13 +30,13 @@ const UIStrings = {
   'is underutilized',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 /** @inheritDoc */
 class FullWidthSlots extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -100,5 +101,5 @@ class FullWidthSlots extends Audit {
   }
 }
 
-module.exports = FullWidthSlots;
-module.exports.UIStrings = UIStrings;
+export default FullWidthSlots;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/full-width-slots.js
+++ b/lighthouse-plugin-publisher-ads/audits/full-width-slots.js
@@ -36,7 +36,6 @@ const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 class FullWidthSlots extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/gpt-bids-parallel.js
+++ b/lighthouse-plugin-publisher-ads/audits/gpt-bids-parallel.js
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
-const {assert} = require('../utils/asserts');
-const {auditNotApplicable} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
-const {getCriticalGraph} = require('../utils/graph');
-const {getTimingsByRecord} = require('../utils/network-timing');
-const {isGptImplTag, isBidRequest, getHeaderBidder} = require('../utils/resource-classification');
+import NetworkRecords from 'lighthouse/lighthouse-core/computed/network-records.js';
+
+import {assert} from '../utils/asserts.js';
+import {auditNotApplicable} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
+import {getCriticalGraph} from '../utils/graph.js';
+import {getTimingsByRecord} from '../utils/network-timing.js';
+import {isGptImplTag, isBidRequest, getHeaderBidder} from '../utils/resource-classification.js';
 
 /** @typedef {LH.Artifacts.NetworkRequest} NetworkRequest */
 /** @typedef {LH.Gatherer.Simulation.NodeTiming} NodeTiming */
@@ -56,7 +57,7 @@ const HEADINGS = [
 class GptBidsInParallel extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -123,5 +124,5 @@ class GptBidsInParallel extends Audit {
   }
 }
 
-module.exports = GptBidsInParallel;
-module.exports.UIStrings = UIStrings;
+export default GptBidsInParallel;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/gpt-bids-parallel.js
+++ b/lighthouse-plugin-publisher-ads/audits/gpt-bids-parallel.js
@@ -57,7 +57,6 @@ const HEADINGS = [
 class GptBidsInParallel extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/gpt-errors-overall.js
+++ b/lighthouse-plugin-publisher-ads/audits/gpt-errors-overall.js
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
-const {auditNotApplicable} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
-const {isGpt, isGptImplTag} = require('../utils/resource-classification');
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+
+import NetworkRecords from 'lighthouse/lighthouse-core/computed/network-records.js';
+import {auditNotApplicable} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
+import {isGpt, isGptImplTag} from '../utils/resource-classification.js';
 
 const UIStrings = {
   title: 'GPT Errors',
@@ -28,7 +29,7 @@ const UIStrings = {
   displayValue: '{numErrors, plural, =1 {1 error} other {# errors}} found',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 /**
  * Audit that checks for the presence of errors and exceptions from the console
@@ -37,7 +38,7 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 class GptErrorsOverall extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -100,5 +101,5 @@ class GptErrorsOverall extends Audit {
   }
 }
 
-module.exports = GptErrorsOverall;
-module.exports.UIStrings = UIStrings;
+export default GptErrorsOverall;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/gpt-errors-overall.js
+++ b/lighthouse-plugin-publisher-ads/audits/gpt-errors-overall.js
@@ -38,7 +38,6 @@ const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 class GptErrorsOverall extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/idle-network-times.js
+++ b/lighthouse-plugin-publisher-ads/audits/idle-network-times.js
@@ -12,18 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const MainThreadTasks = require('lighthouse/lighthouse-core/computed/main-thread-tasks.js');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+
+import MainThreadTasks from 'lighthouse/lighthouse-core/computed/main-thread-tasks.js';
+import NetworkRecords from 'lighthouse/lighthouse-core/computed/network-records.js';
+
 // @ts-expect-error
-const ProcessedTrace = require('lighthouse/lighthouse-core/computed/processed-trace.js');
+import ProcessedTrace from 'lighthouse/lighthouse-core/computed/processed-trace.js';
+
 // @ts-expect-error
-const ProcessedNavigation = require('lighthouse/lighthouse-core/computed/processed-navigation.js');
-const {auditNotApplicable} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
-const {computeAdRequestWaterfall} = require('../utils/graph');
-const {getAttributableUrl} = require('../utils/tasks');
-const {getPageStartTime} = require('../utils/network-timing');
+import ProcessedNavigation from 'lighthouse/lighthouse-core/computed/processed-navigation.js';
+
+import {auditNotApplicable} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
+import {computeAdRequestWaterfall} from '../utils/graph.js';
+import {getAttributableUrl} from '../utils/tasks.js';
+import {getPageStartTime} from '../utils/network-timing.js';
 
 const UIStrings = {
   title: '[Experimental] Network is efficiently utilized before ad requests',
@@ -48,7 +52,7 @@ const UIStrings = {
   causeOther: 'Other',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 /** @enum {string} */
 const Cause = {
@@ -244,7 +248,7 @@ function determineCause(
 class IdleNetworkTimes extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -327,5 +331,5 @@ class IdleNetworkTimes extends Audit {
   }
 }
 
-module.exports = IdleNetworkTimes;
-module.exports.UIStrings = UIStrings;
+export default IdleNetworkTimes;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/idle-network-times.js
+++ b/lighthouse-plugin-publisher-ads/audits/idle-network-times.js
@@ -248,7 +248,6 @@ function determineCause(
 class IdleNetworkTimes extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/loads-ad-tag-over-https.js
+++ b/lighthouse-plugin-publisher-ads/audits/loads-ad-tag-over-https.js
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
-const {auditNotApplicable} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
-const {isAdTag} = require('../utils/resource-classification');
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+
+import NetworkRecords from 'lighthouse/lighthouse-core/computed/network-records.js';
+import {auditNotApplicable} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
+import {isAdTag} from '../utils/resource-classification.js';
+
 const UIStrings = {
   title: 'Ad tag is loaded over HTTPS',
   failureTitle: 'Load ad tag over HTTPS',
@@ -31,7 +33,7 @@ const UIStrings = {
   ').',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 
 /**
@@ -42,7 +44,7 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 class LoadsAdTagOverHttps extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -96,5 +98,5 @@ class LoadsAdTagOverHttps extends Audit {
   }
 }
 
-module.exports = LoadsAdTagOverHttps;
-module.exports.UIStrings = UIStrings;
+export default LoadsAdTagOverHttps;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/loads-ad-tag-over-https.js
+++ b/lighthouse-plugin-publisher-ads/audits/loads-ad-tag-over-https.js
@@ -44,7 +44,6 @@ const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 class LoadsAdTagOverHttps extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/loads-gpt-from-official-source.js
+++ b/lighthouse-plugin-publisher-ads/audits/loads-gpt-from-official-source.js
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
-const {auditNotApplicable} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
-const {isGptTag} = require('../utils/resource-classification');
-const {URL} = require('url');
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+
+import NetworkRecords from 'lighthouse/lighthouse-core/computed/network-records.js';
+import {auditNotApplicable} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
+import {isGptTag} from '../utils/resource-classification.js';
+import {URL} from 'url';
 
 const UIStrings = {
   title: 'GPT tag is loaded from an official source',
@@ -30,7 +31,7 @@ const UIStrings = {
   ').',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 /**
  * Simple audit that checks if gpt is loaded over from updated host.
@@ -38,7 +39,7 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 class LoadsGptFromOfficalSource extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -74,5 +75,5 @@ class LoadsGptFromOfficalSource extends Audit {
   }
 }
 
-module.exports = LoadsGptFromOfficalSource;
-module.exports.UIStrings = UIStrings;
+export default LoadsGptFromOfficalSource;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/loads-gpt-from-official-source.js
+++ b/lighthouse-plugin-publisher-ads/audits/loads-gpt-from-official-source.js
@@ -39,7 +39,6 @@ const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 class LoadsGptFromOfficalSource extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/script-injected-tags.js
+++ b/lighthouse-plugin-publisher-ads/audits/script-injected-tags.js
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const array = require('../utils/array.js');
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const PageDependencyGraph = require('lighthouse/lighthouse-core/computed/page-dependency-graph.js');
-const {auditNotApplicable} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
-const {computeAdRequestWaterfall} = require('../utils/graph');
-const {getScriptEvaluationTimes} = require('../utils/network-timing');
+import * as array from '../utils/array.js';
+
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+import PageDependencyGraph from 'lighthouse/lighthouse-core/computed/page-dependency-graph.js';
+import {auditNotApplicable} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
+import {computeAdRequestWaterfall} from '../utils/graph.js';
+import {getScriptEvaluationTimes} from '../utils/network-timing.js';
 
 /** @typedef {LH.Artifacts.NetworkRequest} NetworkRequest */
 /** @typedef {LH.Gatherer.Simulation.NodeTiming} NodeTiming */
@@ -40,7 +41,7 @@ const UIStrings = {
   columnLoadTime: 'Load Time',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 /**
  * Table headings for audits details sections.
@@ -124,7 +125,7 @@ async function findStaticallyLoadableTags(artifacts, context) {
 class StaticAdTags extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -186,5 +187,5 @@ class StaticAdTags extends Audit {
   }
 }
 
-module.exports = StaticAdTags;
-module.exports.UIStrings = UIStrings;
+export default StaticAdTags;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/script-injected-tags.js
+++ b/lighthouse-plugin-publisher-ads/audits/script-injected-tags.js
@@ -125,7 +125,6 @@ async function findStaticallyLoadableTags(artifacts, context) {
 class StaticAdTags extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/serial-header-bidding.js
+++ b/lighthouse-plugin-publisher-ads/audits/serial-header-bidding.js
@@ -12,17 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const ComputedAdRequestTime = require('../computed/ad-request-time');
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
+import ComputedAdRequestTime from '../computed/ad-request-time.js';
+
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+
 // @ts-ignore
-const MainResource = require('lighthouse/lighthouse-core/computed/main-resource.js');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
-const {auditNotApplicable} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
-const {bucket} = require('../utils/array');
-const {getTimingsByRecord} = require('../utils/network-timing');
-const {isCacheable} = require('../utils/network');
-const {isGoogleAds, getHeaderBidder} = require('../utils/resource-classification');
+import MainResource from 'lighthouse/lighthouse-core/computed/main-resource.js';
+
+import NetworkRecords from 'lighthouse/lighthouse-core/computed/network-records.js';
+import {auditNotApplicable} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
+import {bucket} from '../utils/array.js';
+import {getTimingsByRecord} from '../utils/network-timing.js';
+import {isCacheable} from '../utils/network.js';
+import {isGoogleAds, getHeaderBidder} from '../utils/resource-classification.js';
 
 /** @typedef {LH.Artifacts.NetworkRequest} NetworkRequest */
 /** @typedef {LH.Gatherer.Simulation.NodeTiming} NodeTiming */
@@ -40,7 +43,7 @@ const UIStrings = {
   columnDuration: 'Duration',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 // Min record duration (s) to be considered a bid.
 const MIN_BID_DURATION = .05;
@@ -143,7 +146,7 @@ function clearQueryString(url) {
 class SerialHeaderBidding extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -242,5 +245,5 @@ class SerialHeaderBidding extends Audit {
   }
 }
 
-module.exports = SerialHeaderBidding;
-module.exports.UIStrings = UIStrings;
+export default SerialHeaderBidding;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/serial-header-bidding.js
+++ b/lighthouse-plugin-publisher-ads/audits/serial-header-bidding.js
@@ -146,7 +146,6 @@ function clearQueryString(url) {
 class SerialHeaderBidding extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
+++ b/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const ComputedTagLoadTime = require('../computed/tag-load-time');
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const {auditNotApplicable, runWarning} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
+import ComputedTagLoadTime from '../computed/tag-load-time.js';
+
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+import {auditNotApplicable, runWarning} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
 
 const UIStrings = {
   title: 'Tag load time',
@@ -28,7 +29,7 @@ const UIStrings = {
   displayValue: '{timeInMs, number, seconds} s',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 /**
  * Audit to determine time for tag to load relative to page start.
@@ -36,7 +37,7 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 class TagLoadTime extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -103,5 +104,5 @@ class TagLoadTime extends Audit {
     };
   }
 }
-module.exports = TagLoadTime;
-module.exports.UIStrings = UIStrings;
+export default TagLoadTime;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
+++ b/lighthouse-plugin-publisher-ads/audits/tag-load-time.js
@@ -37,7 +37,6 @@ const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 class TagLoadTime extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/total-ad-blocking-time.js
+++ b/lighthouse-plugin-publisher-ads/audits/total-ad-blocking-time.js
@@ -8,13 +8,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const LongTasks = require('../computed/long-tasks');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
-const {auditNotApplicable} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
-const {getAttributableUrl} = require('../utils/tasks');
-const {isAdRelated, getNameOrTld} = require('../utils/resource-classification');
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+
+import LongTasks from '../computed/long-tasks.js';
+import NetworkRecords from 'lighthouse/lighthouse-core/computed/network-records.js';
+import {auditNotApplicable} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
+import {getAttributableUrl} from '../utils/tasks.js';
+import {isAdRelated, getNameOrTld} from '../utils/resource-classification.js';
 
 const UIStrings = {
   /* Title of the audit */
@@ -29,7 +30,7 @@ const UIStrings = {
   columnBlockingTime: 'Blocking Time',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 /**
  * @typedef {Object} TableRow
  * @property {number} blockingTime
@@ -58,7 +59,7 @@ const HEADINGS = [
 class TotalAdBlockingTime extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -152,5 +153,5 @@ class TotalAdBlockingTime extends Audit {
   }
 }
 
-module.exports = TotalAdBlockingTime;
-module.exports.UIStrings = UIStrings;
+export default TotalAdBlockingTime;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/total-ad-blocking-time.js
+++ b/lighthouse-plugin-publisher-ads/audits/total-ad-blocking-time.js
@@ -59,7 +59,6 @@ const HEADINGS = [
 class TotalAdBlockingTime extends Audit {
   /**
    * @return {LH.Audit.Meta}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/audits/viewport-ad-density.js
+++ b/lighthouse-plugin-publisher-ads/audits/viewport-ad-density.js
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const {auditNotApplicable, auditError} = require('../messages/common-strings');
-const {Audit} = require('lighthouse');
-const {isAdIframe} = require('../utils/resource-classification');
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+
+import {auditNotApplicable, auditError} from '../messages/common-strings.js';
+import {Audit} from 'lighthouse';
+import {isAdIframe} from '../utils/resource-classification.js';
 
 const UIStrings = {
   title: 'Ads to page-height ratio is within recommended range',
@@ -27,7 +28,7 @@ const UIStrings = {
   displayValue: '{adDensity, number, percent} ads to page-height ratio',
 };
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 /**
  * @param {LH.Artifacts.IFrameElement[]} slots
@@ -82,7 +83,7 @@ function computeAdLength(slots, viewport) {
 class ViewportAdDensity extends Audit {
   /**
    * @return {AuditMetadata}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {
@@ -134,5 +135,5 @@ class ViewportAdDensity extends Audit {
   }
 }
 
-module.exports = ViewportAdDensity;
-module.exports.UIStrings = UIStrings;
+export default ViewportAdDensity;
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/audits/viewport-ad-density.js
+++ b/lighthouse-plugin-publisher-ads/audits/viewport-ad-density.js
@@ -83,7 +83,6 @@ function computeAdLength(slots, viewport) {
 class ViewportAdDensity extends Audit {
   /**
    * @return {AuditMetadata}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get meta() {
     return {

--- a/lighthouse-plugin-publisher-ads/computed/ad-lantern-metric.js
+++ b/lighthouse-plugin-publisher-ads/computed/ad-lantern-metric.js
@@ -12,14 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const BaseNode = require('lighthouse/lighthouse-core/lib/dependency-graph/base-node.js');
+import {BaseNode} from 'lighthouse/lighthouse-core/lib/dependency-graph/base-node.js';
+
 // eslint-disable-next-line no-unused-vars
-const CpuNode = require('lighthouse/lighthouse-core/lib/dependency-graph/cpu-node.js');
+import {CPUNode} from 'lighthouse/lighthouse-core/lib/dependency-graph/cpu-node.js';
+
 // @ts-ignore Remove request() below after importing the type.
-const LanternMetric = require('lighthouse/lighthouse-core/computed/metrics/lantern-metric.js');
+import LanternMetric from 'lighthouse/lighthouse-core/computed/metrics/lantern-metric.js';
+
 // eslint-disable-next-line no-unused-vars
-const NetworkNode = require('lighthouse/lighthouse-core/lib/dependency-graph/network-node.js');
-const {isBidRelatedRequest, isImpressionPing, isGoogleAds, isGptAdRequest, isGptTag, isGptImplTag, toURL} = require('../utils/resource-classification');
+import {NetworkNode} from 'lighthouse/lighthouse-core/lib/dependency-graph/network-node.js';
+
+import {
+  isBidRelatedRequest,
+  isImpressionPing,
+  isGoogleAds,
+  isGptAdRequest,
+  isGptTag,
+  isGptImplTag,
+  toURL,
+} from '../utils/resource-classification.js';
 
 /** @typedef {LH.Gatherer.Simulation.GraphNode} GraphNode */
 /** @typedef {LH.Gatherer.Simulation.NodeTiming} NodeTiming */
@@ -36,7 +48,7 @@ function getFrame(event) {
 
 /**
  * Returns a list of URLs associated with this CPU node.
- * @param {CpuNode} cpuNode
+ * @param {CPUNode} cpuNode
  * @return {string[]}
  */
 function getCpuNodeUrls(cpuNode) {
@@ -51,7 +63,7 @@ function getCpuNodeUrls(cpuNode) {
 
 /**
  * Checks if the given CPU node is related to bidding.
- * @param {CpuNode} cpuNode
+ * @param {CPUNode} cpuNode
  * @return {boolean}
  */
 function isAdTask(cpuNode) {
@@ -61,7 +73,7 @@ function isAdTask(cpuNode) {
 
 /**
  * Checks if the given CPU node is a long task.
- * @param {CpuNode} cpuNode
+ * @param {CPUNode} cpuNode
  * @return {boolean}
  */
 function isLongTask(cpuNode) {
@@ -72,8 +84,8 @@ function isLongTask(cpuNode) {
 
 /**
  * Adds a dependency edge between a nd b, where a came before b.
- * @param {CpuNode|NetworkNode} a
- * @param {CpuNode|NetworkNode} b
+ * @param {CPUNode|NetworkNode} a
+ * @param {CPUNode|NetworkNode} b
  */
 function addEdge(a, b) {
   if (a === b || a.endTime > b.startTime) return;
@@ -129,7 +141,7 @@ function addEdges(graph) {
 class AdLanternMetric extends LanternMetric {
   /**
    * @return {LH.Gatherer.Simulation.MetricCoefficients}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get COEFFICIENTS() {
     return {
@@ -144,7 +156,7 @@ class AdLanternMetric extends LanternMetric {
    * @param {BaseNode} graph Root of the dependency graph, i.e. the
    *     document node.
    * @return {BaseNode}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static getPessimisticGraph(graph) {
     // The pessimistic graph is the whole graph.
@@ -157,7 +169,7 @@ class AdLanternMetric extends LanternMetric {
    * @param {BaseNode} graph Root of the dependency graph, i.e. the
    *     document node.
    * @return {BaseNode}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static getOptimisticGraph(graph) {
     // @ts-ignore
@@ -185,7 +197,7 @@ class AdLanternMetric extends LanternMetric {
    * @param {LH.Gatherer.Simulation.Result} simulationResult
    * @param {Object} extras
    * @return {LH.Gatherer.Simulation.Result}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static getEstimateFromSimulation(simulationResult, extras) {
     throw new Error(
@@ -221,4 +233,4 @@ class AdLanternMetric extends LanternMetric {
   }
 }
 
-module.exports = AdLanternMetric;
+export default AdLanternMetric;

--- a/lighthouse-plugin-publisher-ads/computed/ad-lantern-metric.js
+++ b/lighthouse-plugin-publisher-ads/computed/ad-lantern-metric.js
@@ -141,7 +141,6 @@ function addEdges(graph) {
 class AdLanternMetric extends LanternMetric {
   /**
    * @return {LH.Gatherer.Simulation.MetricCoefficients}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static get COEFFICIENTS() {
     return {
@@ -156,7 +155,6 @@ class AdLanternMetric extends LanternMetric {
    * @param {BaseNode} graph Root of the dependency graph, i.e. the
    *     document node.
    * @return {BaseNode}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static getPessimisticGraph(graph) {
     // The pessimistic graph is the whole graph.
@@ -169,7 +167,6 @@ class AdLanternMetric extends LanternMetric {
    * @param {BaseNode} graph Root of the dependency graph, i.e. the
    *     document node.
    * @return {BaseNode}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static getOptimisticGraph(graph) {
     // @ts-ignore
@@ -197,7 +194,6 @@ class AdLanternMetric extends LanternMetric {
    * @param {LH.Gatherer.Simulation.Result} simulationResult
    * @param {Object} extras
    * @return {LH.Gatherer.Simulation.Result}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static getEstimateFromSimulation(simulationResult, extras) {
     throw new Error(

--- a/lighthouse-plugin-publisher-ads/computed/ad-render-time.js
+++ b/lighthouse-plugin-publisher-ads/computed/ad-render-time.js
@@ -12,13 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const AdLanternMetric = require('./ad-lantern-metric');
+import AdLanternMetric from './ad-lantern-metric.js';
+
 // @ts-ignore
-const ComputedMetric = require('lighthouse/lighthouse-core/computed/metrics/metric.js');
+import ComputedMetric from 'lighthouse/lighthouse-core/computed/metrics/metric.js';
+
 // @ts-ignore
-const makeComputedArtifact = require('lighthouse/lighthouse-core/computed/computed-artifact.js');
-const {getPageStartTime, getImpressionStartTime} = require('../utils/network-timing');
-const {isImpressionPing} = require('../utils/resource-classification');
+import {makeComputedArtifact} from 'lighthouse/lighthouse-core/computed/computed-artifact.js';
+
+import {getPageStartTime, getImpressionStartTime} from '../utils/network-timing.js';
+import {isImpressionPing} from '../utils/resource-classification.js';
 
 // @ts-ignore
 // eslint-disable-next-line max-len
@@ -52,7 +55,7 @@ class AdRenderTime extends ComputedMetric {
    * @param {LH.Artifacts.MetricComputationData} data
    * @param {LH.Audit.Context} context
    * @return {Promise<LH.Artifacts.LanternMetric>}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static async computeSimulatedMetric(data, context) {
     // @ts-ignore request does not exist on LanternAdRenderTime
@@ -63,7 +66,7 @@ class AdRenderTime extends ComputedMetric {
    * @param {LH.Artifacts.MetricComputationData} data
    * @param {LH.Audit.Context} context
    * @return {Promise<LH.Artifacts.Metric>}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static async computeObservedMetric(data, context) {
     const {networkRecords} = data;
@@ -91,5 +94,5 @@ class AdRenderTime extends ComputedMetric {
 // eslint-disable-next-line no-class-assign
 AdRenderTime = makeComputedArtifact(AdRenderTime);
 
-module.exports = AdRenderTime;
+export default AdRenderTime;
 

--- a/lighthouse-plugin-publisher-ads/computed/ad-render-time.js
+++ b/lighthouse-plugin-publisher-ads/computed/ad-render-time.js
@@ -55,7 +55,6 @@ class AdRenderTime extends ComputedMetric {
    * @param {LH.Artifacts.MetricComputationData} data
    * @param {LH.Audit.Context} context
    * @return {Promise<LH.Artifacts.LanternMetric>}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static async computeSimulatedMetric(data, context) {
     // @ts-ignore request does not exist on LanternAdRenderTime
@@ -66,7 +65,6 @@ class AdRenderTime extends ComputedMetric {
    * @param {LH.Artifacts.MetricComputationData} data
    * @param {LH.Audit.Context} context
    * @return {Promise<LH.Artifacts.Metric>}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static async computeObservedMetric(data, context) {
     const {networkRecords} = data;

--- a/lighthouse-plugin-publisher-ads/computed/ad-request-time.js
+++ b/lighthouse-plugin-publisher-ads/computed/ad-request-time.js
@@ -12,13 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const AdLanternMetric = require('./ad-lantern-metric');
+import AdLanternMetric from './ad-lantern-metric.js';
+
 // @ts-ignore
-const ComputedMetric = require('lighthouse/lighthouse-core/computed/metrics/metric.js');
+import ComputedMetric from 'lighthouse/lighthouse-core/computed/metrics/metric.js';
+
 // @ts-ignore
-const makeComputedArtifact = require('lighthouse/lighthouse-core/computed/computed-artifact.js');
-const {getAdStartTime, getPageStartTime} = require('../utils/network-timing');
-const {isAdRequest} = require('../utils/resource-classification');
+import {makeComputedArtifact} from 'lighthouse/lighthouse-core/computed/computed-artifact.js';
+
+import {getAdStartTime, getPageStartTime} from '../utils/network-timing.js';
+import {isAdRequest} from '../utils/resource-classification.js';
 
 // @ts-ignore
 // eslint-disable-next-line max-len
@@ -51,7 +54,7 @@ class AdRequestTime extends ComputedMetric {
    * @param {LH.Artifacts.MetricComputationData} data
    * @param {LH.Audit.Context} context
    * @return {Promise<LH.Artifacts.LanternMetric>}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static async computeSimulatedMetric(data, context) {
     // @ts-ignore request does not exist on LanternAdRequestTime
@@ -61,7 +64,7 @@ class AdRequestTime extends ComputedMetric {
   /**
    * @param {LH.Artifacts.MetricComputationData} data
    * @return {Promise<LH.Artifacts.Metric>}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static async computeObservedMetric(data) {
     const {networkRecords} = data;
@@ -89,4 +92,4 @@ class AdRequestTime extends ComputedMetric {
 // eslint-disable-next-line no-class-assign
 AdRequestTime = makeComputedArtifact(AdRequestTime);
 
-module.exports = AdRequestTime;
+export default AdRequestTime;

--- a/lighthouse-plugin-publisher-ads/computed/ad-request-time.js
+++ b/lighthouse-plugin-publisher-ads/computed/ad-request-time.js
@@ -54,7 +54,6 @@ class AdRequestTime extends ComputedMetric {
    * @param {LH.Artifacts.MetricComputationData} data
    * @param {LH.Audit.Context} context
    * @return {Promise<LH.Artifacts.LanternMetric>}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static async computeSimulatedMetric(data, context) {
     // @ts-ignore request does not exist on LanternAdRequestTime
@@ -64,7 +63,6 @@ class AdRequestTime extends ComputedMetric {
   /**
    * @param {LH.Artifacts.MetricComputationData} data
    * @return {Promise<LH.Artifacts.Metric>}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static async computeObservedMetric(data) {
     const {networkRecords} = data;

--- a/lighthouse-plugin-publisher-ads/computed/bid-request-time.js
+++ b/lighthouse-plugin-publisher-ads/computed/bid-request-time.js
@@ -12,13 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const AdLanternMetric = require('./ad-lantern-metric');
+import AdLanternMetric from './ad-lantern-metric.js';
+
 // @ts-ignore
-const ComputedMetric = require('lighthouse/lighthouse-core/computed/metrics/metric.js');
+import ComputedMetric from 'lighthouse/lighthouse-core/computed/metrics/metric.js';
+
 // @ts-ignore
-const makeComputedArtifact = require('lighthouse/lighthouse-core/computed/computed-artifact.js');
-const {getAdStartTime, getBidStartTime, getPageStartTime} = require('../utils/network-timing');
-const {isAdRequest, isBidRequest} = require('../utils/resource-classification');
+import {makeComputedArtifact} from 'lighthouse/lighthouse-core/computed/computed-artifact.js';
+
+import {getAdStartTime, getBidStartTime, getPageStartTime} from '../utils/network-timing.js';
+import {isAdRequest, isBidRequest} from '../utils/resource-classification.js';
 
 // @ts-ignore
 // eslint-disable-next-line max-len
@@ -56,7 +59,7 @@ class BidRequestTime extends ComputedMetric {
    * @param {LH.Artifacts.MetricComputationData} data
    * @param {LH.Audit.Context} context
    * @return {Promise<LH.Artifacts.LanternMetric>}
-   * @override
+   * /override TODO This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static async computeSimulatedMetric(data, context) {
     // @ts-ignore request does not exist on LanternBidRequestTime
@@ -66,7 +69,7 @@ class BidRequestTime extends ComputedMetric {
   /**
    * @param {LH.Artifacts.MetricComputationData} data
    * @return {Promise<LH.Artifacts.Metric>}
-   * @override
+   * /override TODO This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static async computeObservedMetric(data) {
     const {networkRecords} = data;
@@ -98,4 +101,4 @@ class BidRequestTime extends ComputedMetric {
 // eslint-disable-next-line no-class-assign
 BidRequestTime = makeComputedArtifact(BidRequestTime);
 
-module.exports = BidRequestTime;
+export default BidRequestTime;

--- a/lighthouse-plugin-publisher-ads/computed/bid-request-time.js
+++ b/lighthouse-plugin-publisher-ads/computed/bid-request-time.js
@@ -59,7 +59,6 @@ class BidRequestTime extends ComputedMetric {
    * @param {LH.Artifacts.MetricComputationData} data
    * @param {LH.Audit.Context} context
    * @return {Promise<LH.Artifacts.LanternMetric>}
-   * /override TODO This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static async computeSimulatedMetric(data, context) {
     // @ts-ignore request does not exist on LanternBidRequestTime
@@ -69,7 +68,6 @@ class BidRequestTime extends ComputedMetric {
   /**
    * @param {LH.Artifacts.MetricComputationData} data
    * @return {Promise<LH.Artifacts.Metric>}
-   * /override TODO This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static async computeObservedMetric(data) {
     const {networkRecords} = data;

--- a/lighthouse-plugin-publisher-ads/computed/long-tasks.js
+++ b/lighthouse-plugin-publisher-ads/computed/long-tasks.js
@@ -12,22 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const AdLanternMetric = require('../computed/ad-lantern-metric');
-const BaseNode = require('lighthouse/lighthouse-core/lib/dependency-graph/base-node.js');
+import AdLanternMetric from '../computed/ad-lantern-metric.js';
+
+import {BaseNode} from 'lighthouse/lighthouse-core/lib/dependency-graph/base-node.js';
+
 // @ts-ignore
-const ComputedMetric = require('lighthouse/lighthouse-core/computed/metrics/metric.js');
+import ComputedMetric from 'lighthouse/lighthouse-core/computed/metrics/metric.js';
+
 // eslint-disable-next-line no-unused-vars
-const CpuNode = require('lighthouse/lighthouse-core/lib/dependency-graph/cpu-node.js');
-const {getAttributableUrl} = require('../utils/tasks');
+import {CPUNode} from 'lighthouse/lighthouse-core/lib/dependency-graph/cpu-node.js';
+
+import {getAttributableUrl} from '../utils/tasks.js';
+
 // @ts-ignore
-const LoadSimulator = require('lighthouse/lighthouse-core/computed/load-simulator.js');
-const MainThreadTasks = require('lighthouse/lighthouse-core/computed/main-thread-tasks.js');
+import LoadSimulator from 'lighthouse/lighthouse-core/computed/load-simulator.js';
+
+import MainThreadTasks from 'lighthouse/lighthouse-core/computed/main-thread-tasks.js';
+
 // @ts-ignore
-const makeComputedArtifact = require('lighthouse/lighthouse-core/computed/computed-artifact.js');
+import {makeComputedArtifact} from 'lighthouse/lighthouse-core/computed/computed-artifact.js';
+
 // eslint-disable-next-line no-unused-vars
-const NetworkNode = require('lighthouse/lighthouse-core/lib/dependency-graph/network-node.js');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
-const PageDependencyGraph = require('lighthouse/lighthouse-core/computed/page-dependency-graph.js');
+import {NetworkNode} from 'lighthouse/lighthouse-core/lib/dependency-graph/network-node.js';
+
+import NetworkRecords from 'lighthouse/lighthouse-core/computed/network-records.js';
+import PageDependencyGraph from 'lighthouse/lighthouse-core/computed/page-dependency-graph.js';
 
 const PROVIDED_LONG_TASK_THRESHOLD_MS = 50;
 const SIMULATED_LONG_TASK_THRESHOLD_MS = 100;
@@ -149,4 +158,4 @@ class LongTasks extends ComputedMetric {
 // eslint-disable-next-line no-class-assign
 LongTasks = makeComputedArtifact(LongTasks);
 
-module.exports = LongTasks;
+export default LongTasks;

--- a/lighthouse-plugin-publisher-ads/computed/tag-load-time.js
+++ b/lighthouse-plugin-publisher-ads/computed/tag-load-time.js
@@ -12,13 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const AdLanternMetric = require('./ad-lantern-metric');
+import AdLanternMetric from './ad-lantern-metric.js';
+
 // @ts-ignore
-const ComputedMetric = require('lighthouse/lighthouse-core/computed/metrics/metric.js');
+import ComputedMetric from 'lighthouse/lighthouse-core/computed/metrics/metric.js';
+
 // @ts-ignore
-const makeComputedArtifact = require('lighthouse/lighthouse-core/computed/computed-artifact.js');
-const {getPageStartTime, getTagEndTime} = require('../utils/network-timing');
-const {isImplTag} = require('../utils/resource-classification');
+import {makeComputedArtifact} from 'lighthouse/lighthouse-core/computed/computed-artifact.js';
+
+import {getPageStartTime, getTagEndTime} from '../utils/network-timing.js';
+import {isImplTag} from '../utils/resource-classification.js';
 
 // @ts-ignore
 // eslint-disable-next-line max-len
@@ -51,7 +54,7 @@ class TagLoadTime extends ComputedMetric {
    * @param {LH.Artifacts.MetricComputationData} data
    * @param {LH.Audit.Context} context
    * @return {Promise<LH.Artifacts.LanternMetric>}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static async computeSimulatedMetric(data, context) {
     // @ts-ignore request does not exist on LanternTagLoadTime
@@ -62,7 +65,7 @@ class TagLoadTime extends ComputedMetric {
    * @param {LH.Artifacts.MetricComputationData} data
    * @param {LH.Audit.Context} context
    * @return {Promise<LH.Artifacts.Metric>}
-   * @override
+   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static async computeObservedMetric(data, context) {
     const {networkRecords} = data;
@@ -90,5 +93,5 @@ class TagLoadTime extends ComputedMetric {
 // eslint-disable-next-line no-class-assign
 TagLoadTime = makeComputedArtifact(TagLoadTime);
 
-module.exports = TagLoadTime;
+export default TagLoadTime;
 

--- a/lighthouse-plugin-publisher-ads/computed/tag-load-time.js
+++ b/lighthouse-plugin-publisher-ads/computed/tag-load-time.js
@@ -54,7 +54,6 @@ class TagLoadTime extends ComputedMetric {
    * @param {LH.Artifacts.MetricComputationData} data
    * @param {LH.Audit.Context} context
    * @return {Promise<LH.Artifacts.LanternMetric>}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static async computeSimulatedMetric(data, context) {
     // @ts-ignore request does not exist on LanternTagLoadTime
@@ -65,7 +64,6 @@ class TagLoadTime extends ComputedMetric {
    * @param {LH.Artifacts.MetricComputationData} data
    * @param {LH.Audit.Context} context
    * @return {Promise<LH.Artifacts.Metric>}
-   * /override This member cannot have a JSDoc comment with an '@override' tag because its containing class ... does not extend another class.
    */
   static async computeObservedMetric(data, context) {
     const {networkRecords} = data;

--- a/lighthouse-plugin-publisher-ads/messages/common-strings.js
+++ b/lighthouse-plugin-publisher-ads/messages/common-strings.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+
 const UIStrings = {
   GROUPS__METRICS: 'Metrics',
   GROUPS__ADS_PERFORMANCE: 'Ad Speed',
@@ -41,9 +43,8 @@ const UIStrings = {
   WARNINGS__NO_AD_RENDERED: 'No ads were rendered when rendering this page.',
   WARNINGS__NO_TAG: 'The GPT tag was not requested.',
 };
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
 
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 /**
  * Returns object for a notApplicable audit given a message string
@@ -97,5 +98,4 @@ const group = {
   AdsBestPractices: str_(UIStrings.GROUPS__ADS_BEST_PRACTICES),
 };
 
-module.exports = {auditNotApplicable, runWarning, auditError, group};
-module.exports.UIStrings = UIStrings;
+export {auditNotApplicable, runWarning, auditError, group, UIStrings};

--- a/lighthouse-plugin-publisher-ads/messages/en-US.json
+++ b/lighthouse-plugin-publisher-ads/messages/en-US.json
@@ -564,19 +564,19 @@
     "description": "Title of the audit"
   },
   "audits/viewport-ad-density.js | description": {
-    "message": "Ad density, the ads-to-content ratio, can impact user experience and ultimately user retention. The Better Ads Standard [recommends having an ad density below 30%](https://www.betterads.org/mobile-ad-density-higher-than-30/). [Learn more](https://developers.google.com/publisher-ads-audits/reference/audits/viewport-ad-density).",
+    "message": "The ads to page-height ratio can impact user experience and ultimately user retention. [Learn more](https://developers.google.com/publisher-ads-audits/reference/audits/viewport-ad-density).",
     "description": ""
   },
   "audits/viewport-ad-density.js | displayValue": {
-    "message": "{adDensity, number, percent} ad density",
+    "message": "{adDensity, number, percent} ads to page-height ratio",
     "description": ""
   },
   "audits/viewport-ad-density.js | failureTitle": {
-    "message": "Reduce ad density",
+    "message": "Reduce ads to page-height ratio",
     "description": ""
   },
   "audits/viewport-ad-density.js | title": {
-    "message": "Ad density is within recommended range",
+    "message": "Ads to page-height ratio is within recommended range",
     "description": ""
   },
   "messages/common-strings.js | ERRORS__AREA_LARGER_THAN_VIEWPORT": {

--- a/lighthouse-plugin-publisher-ads/messages/locales/en-XL.json
+++ b/lighthouse-plugin-publisher-ads/messages/locales/en-XL.json
@@ -423,16 +423,16 @@
     "message": "T̂ót̂ál̂ ád̂ J́Ŝ b́l̂óĉḱîńĝ t́îḿê"
   },
   "audits/viewport-ad-density.js | description": {
-    "message": "Âd́ d̂én̂śît́ŷ, t́ĥé âd́ŝ-t́ô-ćôńt̂én̂t́ r̂át̂íô, ćâń îḿp̂áĉt́ ûśêŕ êx́p̂ér̂íêńĉé âńd̂ úl̂t́îḿât́êĺŷ úŝér̂ ŕêt́êńt̂íôń. T̂h́ê B́êt́t̂ér̂ Ád̂ś Ŝt́âńd̂ár̂d́ [r̂éĉóm̂ḿêńd̂ś ĥáv̂ín̂ǵ âń âd́ d̂én̂śît́ŷ b́êĺôẃ 30%](ĥt́t̂ṕŝ://ẃŵẃ.b̂ét̂t́êŕâd́ŝ.ór̂ǵ/m̂ób̂íl̂é-âd́-d̂én̂śît́ŷ-h́îǵĥér̂-t́ĥán̂-30/). [Ĺêár̂ń m̂ór̂é](ĥt́t̂ṕŝ://d́êv́êĺôṕêŕŝ.ǵôóĝĺê.ćôḿ/p̂úb̂ĺîśĥér̂-ád̂ś-âúd̂ít̂ś/r̂éf̂ér̂én̂ćê/áûd́ît́ŝ/v́îéŵṕôŕt̂-ád̂-d́êńŝít̂ý)."
+    "message": "T̂h́ê ád̂ś t̂ó p̂áĝé-ĥéîǵĥt́ r̂át̂íô ćâń îḿp̂áĉt́ ûśêŕ êx́p̂ér̂íêńĉé âńd̂ úl̂t́îḿât́êĺŷ úŝér̂ ŕêt́êńt̂íôń. [L̂éâŕn̂ ḿôŕê](h́t̂t́p̂ś://d̂év̂él̂óp̂ér̂ś.ĝóôǵl̂é.ĉóm̂/ṕûb́l̂íŝh́êŕ-âd́ŝ-áûd́ît́ŝ/ŕêf́êŕêńĉé/âúd̂ít̂ś/v̂íêẃp̂ór̂t́-âd́-d̂én̂śît́ŷ)."
   },
   "audits/viewport-ad-density.js | displayValue": {
-    "message": "{adDensity, number, percent} âd́ d̂én̂śît́ŷ"
+    "message": "{adDensity, number, percent} âd́ŝ t́ô ṕâǵê-h́êíĝh́t̂ ŕât́îó"
   },
   "audits/viewport-ad-density.js | failureTitle": {
-    "message": "R̂éd̂úĉé âd́ d̂én̂śît́ŷ"
+    "message": "R̂éd̂úĉé âd́ŝ t́ô ṕâǵê-h́êíĝh́t̂ ŕât́îó"
   },
   "audits/viewport-ad-density.js | title": {
-    "message": "Âd́ d̂én̂śît́ŷ íŝ ẃît́ĥín̂ ŕêćôḿm̂én̂d́êd́ r̂án̂ǵê"
+    "message": "Âd́ŝ t́ô ṕâǵê-h́êíĝh́t̂ ŕât́îó îś ŵít̂h́îń r̂éĉóm̂ḿêńd̂éd̂ ŕâńĝé"
   },
   "messages/common-strings.js | ERRORS__AREA_LARGER_THAN_VIEWPORT": {
     "message": "Ĉál̂ćûĺât́êd́ âd́ âŕêá îś l̂ár̂ǵêŕ t̂h́âń v̂íêẃp̂ór̂t́"

--- a/lighthouse-plugin-publisher-ads/package.json
+++ b/lighthouse-plugin-publisher-ads/package.json
@@ -1,6 +1,7 @@
 {
   "name": "lighthouse-plugin-publisher-ads",
   "version": "1.5.6",
+  "type": "module",
   "description": "A Lighthouse plugin to improve ad speed and overall quality through a series of automated audits.",
   "author": "Google Ads",
   "license": "Apache-2.0",

--- a/lighthouse-plugin-publisher-ads/plugin.js
+++ b/lighthouse-plugin-publisher-ads/plugin.js
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const i18n = require('lighthouse/lighthouse-core/lib/i18n/i18n.js');
-const {group} = require('./messages/common-strings');
+import * as i18n from 'lighthouse/lighthouse-core/lib/i18n/i18n.js';
+
+import {group} from './messages/common-strings.js';
 
 const PLUGIN_PATH = 'lighthouse-plugin-publisher-ads';
 
@@ -21,10 +22,10 @@ const UIStrings = {
   categoryDescription: 'A Lighthouse plugin to improve ad speed and overall quality that is targeted at sites using GPT or AdSense tag. ' +
       '[Learn more](https://developers.google.com/publisher-ads-audits/reference)',
 };
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(import.meta.url, UIStrings);
 
 /** @type {LH.Config.Plugin} */
-module.exports = {
+export default {
   audits: [
     {path: `${PLUGIN_PATH}/audits/ad-blocking-tasks`},
     {path: `${PLUGIN_PATH}/audits/ad-render-blocking-resources`},
@@ -96,10 +97,4 @@ module.exports = {
   },
 };
 
-// @ts-ignore Use `defineProperty` so that the strings can be referenced but not
-// iterated over (i.e. set enumerable=false). Otherwise the config would be
-// invalid for having additional keys.
-Object.defineProperty(module.exports, 'UIStrings', {
-  enumerable: false,
-  get: () => UIStrings,
-});
+export {UIStrings};

--- a/lighthouse-plugin-publisher-ads/test/audits/ad-top-of-viewport_test.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/ad-top-of-viewport_test.js
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const AdTopOfViewport = require('../../audits/ad-top-of-viewport');
-const {expect} = require('chai');
+import AdTopOfViewport from '../../audits/ad-top-of-viewport.js';
+
+import chai from 'chai';
+
+const {expect} = chai;
 
 describe('AdTopOfViewport', () => {
   // From top left corner & dimensions

--- a/lighthouse-plugin-publisher-ads/test/audits/ads-in-viewport_test.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/ads-in-viewport_test.js
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const AdsInViewport = require('../../audits/ads-in-viewport');
-const {expect} = require('chai');
+import AdsInViewport from '../../audits/ads-in-viewport.js';
+
+import chai from 'chai';
+
+const {expect} = chai;
 
 describe('AdsInViewport', () => {
   // From top left corner & dimensions

--- a/lighthouse-plugin-publisher-ads/test/audits/async-ad-tags_test.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/async-ad-tags_test.js
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const AsyncAdTags = require('../../audits/async-ad-tags');
-const MainResource = require('lighthouse/lighthouse-core/computed/main-resource.js');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
-const sinon = require('sinon');
-const {expect} = require('chai');
+import AsyncAdTags from '../../audits/async-ad-tags.js';
+
+import MainResource from 'lighthouse/lighthouse-core/computed/main-resource.js';
+import NetworkRecords from 'lighthouse/lighthouse-core/computed/network-records.js';
+import sinon from 'sinon';
+import chai from 'chai';
+
+const {expect} = chai;
 
 describe('AsyncAdTags', async () => {
   let sandbox;

--- a/lighthouse-plugin-publisher-ads/test/audits/full-width-slots_test.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/full-width-slots_test.js
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const chai = require('chai');
-const FullWidthSlots = require('../../audits/full-width-slots');
-const expect = chai.expect;
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
-const sinon = require('sinon');
+import chai from 'chai';
+
+import FullWidthSlots from '../../audits/full-width-slots.js';
+import NetworkRecords from 'lighthouse/lighthouse-core/computed/network-records.js';
+import sinon from 'sinon';
+
+const {expect} = chai;
 
 describe('FullWidthSlots', async () => {
   const ViewportDimensions = {

--- a/lighthouse-plugin-publisher-ads/test/audits/loads-ad-tag-over-https_test.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/loads-ad-tag-over-https_test.js
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const LoadsAdTagOverHttps = require('../../audits/loads-ad-tag-over-https');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
-const sinon = require('sinon');
-const {expect} = require('chai');
+import LoadsAdTagOverHttps from '../../audits/loads-ad-tag-over-https.js';
+
+import NetworkRecords from 'lighthouse/lighthouse-core/computed/network-records.js';
+import sinon from 'sinon';
+import chai from 'chai';
+
+const {expect} = chai;
 
 describe('LoadsAdTagOverHttps', async () => {
   let sandbox;

--- a/lighthouse-plugin-publisher-ads/test/audits/network-records-test-files/ads-related-entry.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/network-records-test-files/ads-related-entry.js
@@ -47,4 +47,4 @@ const networkRecords = [
   },
 ];
 
-module.exports = networkRecords;
+export default networkRecords;

--- a/lighthouse-plugin-publisher-ads/test/audits/network-records-test-files/blank-initiator-details.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/network-records-test-files/blank-initiator-details.js
@@ -33,4 +33,4 @@ const networkRecords = [
   },
 ];
 
-module.exports = networkRecords;
+export default networkRecords;

--- a/lighthouse-plugin-publisher-ads/test/audits/network-records-test-files/cycle.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/network-records-test-files/cycle.js
@@ -151,4 +151,4 @@ const networkRecords = [
   },
 ];
 
-module.exports = networkRecords;
+export default networkRecords;

--- a/lighthouse-plugin-publisher-ads/test/audits/network-records-test-files/diamond-dependency.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/network-records-test-files/diamond-dependency.js
@@ -113,4 +113,4 @@ const networkRecords = [
   },
 ];
 
-module.exports = networkRecords;
+export default networkRecords;

--- a/lighthouse-plugin-publisher-ads/test/audits/network-records-test-files/multiple-dependencies.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/network-records-test-files/multiple-dependencies.js
@@ -102,4 +102,4 @@ const networkRecords = [
   },
 ];
 
-module.exports = networkRecords;
+export default networkRecords;

--- a/lighthouse-plugin-publisher-ads/test/audits/network-records-test-files/multiple-entries.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/network-records-test-files/multiple-entries.js
@@ -87,4 +87,4 @@ const networkRecords = [
   },
 ];
 
-module.exports = networkRecords;
+export default networkRecords;

--- a/lighthouse-plugin-publisher-ads/test/audits/network-records-test-files/multiple-pubads-entries.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/network-records-test-files/multiple-pubads-entries.js
@@ -141,4 +141,4 @@ const networkRecords = [
   },
 ];
 
-module.exports = networkRecords;
+export default networkRecords;

--- a/lighthouse-plugin-publisher-ads/test/audits/network-records-test-files/multiple-pubads-single.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/network-records-test-files/multiple-pubads-single.js
@@ -127,4 +127,4 @@ const networkRecords = [
   },
 ];
 
-module.exports = networkRecords;
+export default networkRecords;

--- a/lighthouse-plugin-publisher-ads/test/audits/network-records-test-files/non-ads-entries.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/network-records-test-files/non-ads-entries.js
@@ -44,4 +44,4 @@ const networkRecords = [
   },
 ];
 
-module.exports = networkRecords;
+export default networkRecords;

--- a/lighthouse-plugin-publisher-ads/test/audits/network-records-test-files/non-script-entries.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/network-records-test-files/non-script-entries.js
@@ -44,4 +44,4 @@ const networkRecords = [
   },
 ];
 
-module.exports = networkRecords;
+export default networkRecords;

--- a/lighthouse-plugin-publisher-ads/test/audits/network-records-test-files/not-in-graph.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/network-records-test-files/not-in-graph.js
@@ -87,4 +87,4 @@ const networkRecords = [
   // have entry that does not have a callframe reference it
 ];
 
-module.exports = networkRecords;
+export default networkRecords;

--- a/lighthouse-plugin-publisher-ads/test/audits/viewport-ad-density_test.js
+++ b/lighthouse-plugin-publisher-ads/test/audits/viewport-ad-density_test.js
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const ViewportAdDensity = require('../../audits/viewport-ad-density');
-const {expect} = require('chai');
+import ViewportAdDensity from '../../audits/viewport-ad-density.js';
+
+import chai from 'chai';
+
+const {expect} = chai;
 
 describe('ViewportAdDensity', () => {
   // From top left corner & dimensions

--- a/lighthouse-plugin-publisher-ads/test/smoke/config.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/config.js
@@ -21,7 +21,7 @@
  * @const {LH.Config}
  */
 // TODO(jburger): Make Chrome run in headless mode.
-module.exports = {
+export default {
   extends: 'lighthouse:default',
   plugins: ['lighthouse-plugin-publisher-ads'],
   passes: [

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/cumulative-ad-shift.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/cumulative-ad-shift.js
@@ -16,7 +16,7 @@
 /**
  * Expected Lighthouse audit values for perf tests.
  */
-module.exports = [
+export default [
   {
     lhr: {
       requestedUrl: 'http://localhost:8081/layout-shift.html',

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/deprecated-api-usage.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/deprecated-api-usage.js
@@ -16,7 +16,7 @@
 /**
  * Expected Lighthouse audit values for perf tests.
  */
-module.exports = [
+export default [
   {
     lhr: {
       requestedUrl: 'http://localhost:8081/deprecated-api-usage.html',

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/duplicate-tags.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/duplicate-tags.js
@@ -16,7 +16,7 @@
 /**
  * Expected Lighthouse audit values for perf tests.
  */
-module.exports = [
+export default [
   {
     lhr: {
       requestedUrl: 'http://localhost:8081/duplicate-tags.html',

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/gpt-errors-overall.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/gpt-errors-overall.js
@@ -16,7 +16,7 @@
 /**
  * Expected Lighthouse audit values for perf tests.
  */
-module.exports = [
+export default [
   {
     lhr: {
       requestedUrl: 'http://localhost:8081/gpt-errors-overall.html',

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/lazy-load.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/lazy-load.js
@@ -16,7 +16,7 @@
 /**
  * Expected Lighthouse audit values for perf tests.
  */
-module.exports = [
+export default [
   {
     lhr: {
       requestedUrl: 'http://localhost:8081/lazy-load.html',

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/limited-ads-dynamic-loading.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/limited-ads-dynamic-loading.js
@@ -16,7 +16,7 @@
 /**
  * Expected Lighthouse audit values for perf tests.
  */
-module.exports = [
+export default [
   {
     lhr: {
       requestedUrl: 'http://localhost:8081/limited-ads-dynamic-loading.html',

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/long-tasks.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/long-tasks.js
@@ -16,7 +16,7 @@
 /**
  * Expected Lighthouse audit values for perf tests.
  */
-module.exports = [
+export default [
   {
     lhr: {
       requestedUrl: 'http://localhost:8081/long-tasks.html',

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/not-applicable.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/not-applicable.js
@@ -16,7 +16,7 @@
 /**
  * Expected Lighthouse audit values for perf tests.
  */
-module.exports = [
+export default [
   {
     lhr: {
       requestedUrl: 'http://localhost:8081/not-applicable.html',

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/render-blocking-tags.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/render-blocking-tags.js
@@ -16,7 +16,7 @@
 /**
  * Expected Lighthouse audit values for perf tests.
  */
-module.exports = [
+export default [
   {
     lhr: {
       requestedUrl: 'http://localhost:8081/render-blocking-tags.html',

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/script-injected.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/script-injected.js
@@ -16,7 +16,7 @@
 /**
  * Expected Lighthouse audit values for perf tests.
  */
-module.exports = [
+export default [
   {
     lhr: {
       requestedUrl: 'http://localhost:8081/script-injected.html',

--- a/lighthouse-plugin-publisher-ads/test/smoke/expectations/top-of-viewport.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/expectations/top-of-viewport.js
@@ -16,7 +16,7 @@
 /**
  * Expected Lighthouse audit values for perf tests.
  */
-module.exports = [
+export default [
   {
     lhr: {
       requestedUrl: 'http://localhost:8081/top-of-viewport.html',

--- a/lighthouse-plugin-publisher-ads/test/smoke/run-smoke.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/run-smoke.js
@@ -14,13 +14,33 @@
 'use strict';
 
 /* eslint-disable no-console */
-const {promisify} = require('util'); // eslint-disable-line
-const execAsync = promisify(require('child_process').exec);
-const StaticServer = require('static-server');
-const {execSync} = require('child_process');
+import { promisify } from 'util'; // eslint-disable-line
+import {exec} from 'child_process';
+import url from 'url';
+import path from 'path';
+import StaticServer from 'static-server';
+import {execSync} from 'child_process';
+
+const execAsync = promisify(exec);
+
+/**
+ * @param {ImportMeta} importMeta
+ */
+function getModulePath(importMeta) {
+  return url.fileURLToPath(importMeta.url);
+}
+
+/**
+ * @param {ImportMeta} importMeta
+ */
+function getModuleDirectory(importMeta) {
+  return path.dirname(getModulePath(importMeta));
+}
+
+const moduleDir = getModuleDirectory(import.meta);
 
 const server = new StaticServer({
-  rootPath: `${__dirname}/fixtures`,
+  rootPath: `${moduleDir}/fixtures`,
   port: 8081,
 });
 

--- a/lighthouse-plugin-publisher-ads/test/smoke/serve-fixtures.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/serve-fixtures.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 'use strict';
-const StaticServer = require('static-server');
+import StaticServer from 'static-server';
 
 const server = new StaticServer({
   rootPath: `${__dirname}/fixtures`,

--- a/lighthouse-plugin-publisher-ads/test/smoke/smoke-test-dfns.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/smoke-test-dfns.js
@@ -11,61 +11,72 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-'use strict';
+
+import deprecatedApiUsage from './expectations/deprecated-api-usage.js';
+import duplicateTags from './expectations/duplicate-tags.js';
+import lazyLoad from './expectations/lazy-load.js';
+import longTasks from './expectations/long-tasks.js';
+import renderBlockingTags from './expectations/render-blocking-tags.js';
+import scriptInjected from './expectations/script-injected.js';
+import topOfViewport from './expectations/top-of-viewport.js';
+import notApplicable from './expectations/not-applicable.js';
+import limitedAdsDynamicLoading from './expectations/limited-ads-dynamic-loading.js';
+import cumulativeAdShift from './expectations/cumulative-ad-shift.js';
+import config from './config.js';
 
 /** @type {Array<Smokehouse.TestDfn>} */
 const smokeTests = [
   // TODO(jburger): Add back `gpt-error-overall` case once fix reaches prod.
   {
     id: 'deprecated-api-usage',
-    expectations: require('./expectations/deprecated-api-usage.js'),
-    config: require('./config.js'),
+    expectations: deprecatedApiUsage,
+    config,
   },
   {
     id: 'duplicate-tags',
-    expectations: require('./expectations/duplicate-tags.js'),
-    config: require('./config.js'),
+    expectations: duplicateTags,
+    config,
   },
   {
     id: 'lazy-load',
-    expectations: require('./expectations/lazy-load.js'),
-    config: require('./config.js'),
+    expectations: lazyLoad,
+    config,
   },
   {
     id: 'long-tasks',
-    expectations: require('./expectations/long-tasks.js'),
-    config: require('./config.js'),
+    expectations: longTasks,
+    config,
   },
   {
     id: 'render-blocking-tasks',
-    expectations: require('./expectations/render-blocking-tags.js'),
-    config: require('./config.js'),
+    expectations: renderBlockingTags,
+    config,
   },
   {
     id: 'script-injected',
-    expectations: require('./expectations/script-injected.js'),
-    config: require('./config.js'),
+    expectations: scriptInjected,
+    config,
   },
   {
     id: 'top-of-viewport',
-    expectations: require('./expectations/top-of-viewport.js'),
-    config: require('./config.js'),
+    expectations: topOfViewport,
+    config,
   },
   {
     id: 'not-applicable',
-    expectations: require('./expectations/not-applicable.js'),
-    config: require('./config.js'),
+    expectations: notApplicable,
+    config,
   },
   {
     id: 'limited-ads-dynamic-loading',
-    expectations: require('./expectations/limited-ads-dynamic-loading.js'),
-    config: require('./config.js'),
+    expectations: limitedAdsDynamicLoading,
+    config,
   },
   {
     id: 'cumulative-ad-shift',
-    expectations: require('./expectations/cumulative-ad-shift.js'),
-    config: require('./config.js'),
+    expectations: cumulativeAdShift,
+    config,
   },
 ];
 
-module.exports = smokeTests;
+export default smokeTests;

--- a/lighthouse-plugin-publisher-ads/test/utils/array_test.js
+++ b/lighthouse-plugin-publisher-ads/test/utils/array_test.js
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const array = require('../../utils/array');
-const {expect} = require('chai');
-const {isGoogleAds} = require('../../utils/resource-classification');
+import * as array from '../../utils/array.js';
+
+import chai from 'chai';
+import {isGoogleAds} from '../../utils/resource-classification.js';
+
+const {expect} = chai;
 
 describe('array', () => {
   describe('#count', () => {

--- a/lighthouse-plugin-publisher-ads/test/utils/geometry_test.js
+++ b/lighthouse-plugin-publisher-ads/test/utils/geometry_test.js
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const geometry = require('../../utils/geometry');
-const {expect} = require('chai');
+import * as geometry from '../../utils/geometry.js';
+
+import chai from 'chai';
+
+const {expect} = chai;
 
 describe('geometry', () => {
   // From top left corner & dimensions

--- a/lighthouse-plugin-publisher-ads/test/utils/network_test.js
+++ b/lighthouse-plugin-publisher-ads/test/utils/network_test.js
@@ -13,10 +13,13 @@
 // limitations under the License.
 //
 //
-const network = require('../../utils/network');
-const {expect} = require('chai');
+import * as network from '../../utils/network.js';
 
-describe('utils/network', () => {
+import chai from 'chai';
+
+const {expect} = chai;
+
+describe('utils/network.js', () => {
   describe('isCacheable', () => {
     const testCases = [
       {

--- a/lighthouse-plugin-publisher-ads/test/utils/resource-classification_test.js
+++ b/lighthouse-plugin-publisher-ads/test/utils/resource-classification_test.js
@@ -12,10 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const {expect} = require('chai');
-const {isGoogleAds, isGptAdRequest, isImpressionPing, isGptTag, isGptImplTag, isAMPTag, isAMPAdRequest, isAdRelated} = require('../../utils/resource-classification');
+import chai from 'chai';
 
-describe('resource-classification', () => {
+const {expect} = chai;
+
+import {
+  isGoogleAds,
+  isGptAdRequest,
+  isImpressionPing,
+  isGptTag,
+  isGptImplTag,
+  isAMPTag,
+  isAMPAdRequest,
+  isAdRelated,
+} from '../../utils/resource-classification.js';
+
+describe('resource-classification.js', () => {
   describe('#isGoogleAds', () => {
     const testCases = [
       {

--- a/lighthouse-plugin-publisher-ads/tsconfig.json
+++ b/lighthouse-plugin-publisher-ads/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "compilerOptions": {
     "noEmit": true,
-    "module": "CommonJS",
-    "target": "ES2017",
+    "module": "es2022",
+    "target": "es2020",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
     "allowJs": true,
     "checkJs": true,
     "resolveJsonModule": true,
@@ -17,13 +19,20 @@
   "include": [
     "**/*.js",
     "**/*.d.ts",
+    "../node_modules/lighthouse/types/lookup-closest-locale/index.d.ts",
+    "../node_modules/lighthouse/shared/*.js",
+    "../node_modules/lighthouse/shared/localization/*.js",
+    "../node_modules/lighthouse/root.js",
+    "../node_modules/lighthouse/esm-utils.js",
     "../node_modules/lighthouse/lighthouse-core/report/html/renderer/util.js",
     "../node_modules/lighthouse/lighthouse-core/report/html/renderer/i18n.js",
     "../node_modules/lighthouse/lighthouse-core/lib/network-request.js",
     "../node_modules/lighthouse/lighthouse-core/lib/url-shim.js",
-    "../node_modules/lighthouse/lighthouse-core/util-commonjs.js",
+    "../node_modules/lighthouse/lighthouse-core/lib/lh-error.js",
+    "../node_modules/lighthouse/lighthouse-core/lib/i18n/*.js",
+    "../node_modules/lighthouse/lighthouse-core/util.cjs",
     "../node_modules/lighthouse/lighthouse-core/lib/dependency-graph/*.js",
-    "../node_modules/lighthouse/lighthouse-core/lib/third-party-web.js"
+    "../node_modules/lighthouse/lighthouse-core/lib/third-party-web.js",
   ],
   "exclude": [
     "test/**/*.js",

--- a/lighthouse-plugin-publisher-ads/typings/lh-externs.d.ts
+++ b/lighthouse-plugin-publisher-ads/typings/lh-externs.d.ts
@@ -19,20 +19,23 @@
  *
  *   find node_modules/lighthouse/types node_modules/lighthouse/types/lhr -name '*.d.ts' -maxdepth 1 | sed -E "s#node_modules/(.*).d.ts#import '\1';#g"
  */
- import 'lighthouse/types/jest';
+ import 'lighthouse/types/user-flow';
  import 'lighthouse/types/audit';
  import 'lighthouse/types/smokehouse';
  import 'lighthouse/types/global-lh';
  import 'lighthouse/types/gatherer';
  import 'lighthouse/types/config';
+ import 'lighthouse/types/rollup-plugin-postprocess';
  import 'lighthouse/types/structured-data';
  import 'lighthouse/types/enquirer';
+ import 'lighthouse/types/test';
  import 'lighthouse/types/node-fetch';
  import 'lighthouse/types/protocol';
  import 'lighthouse/types/externs';
  import 'lighthouse/types/jsonlint-mod';
  import 'lighthouse/types/query-selector';
  import 'lighthouse/types/node';
+ import 'lighthouse/types/es-main';
  import 'lighthouse/types/artifacts';
  import 'lighthouse/types/lhr/settings';
  import 'lighthouse/types/lhr/lhr';

--- a/lighthouse-plugin-publisher-ads/typings/lighthouse.d.ts
+++ b/lighthouse-plugin-publisher-ads/typings/lighthouse.d.ts
@@ -81,15 +81,27 @@ declare module 'lighthouse-logger' {
 }
 
 declare module 'lighthouse/lighthouse-core/computed/network-records.js' {
-  export function request(devToolsLog: LH.DevtoolsLog, context: LH.Audit.Context): Promise<Array<LH.Artifacts.NetworkRequest>>;
+  export default {
+    request(devToolsLog: LH.DevtoolsLog, context: LH.Audit.Context): Promise<Array<LH.Artifacts.NetworkRequest>>;
+  }
+}
+
+declare module 'lighthouse/lighthouse-core/computed/main-resource.js' {
+  export default {
+    request(data: {URL: LH.Artifacts['URL'], devtoolsLog: LH.DevtoolsLog}, context: LH.Audit.Context): Promise<LH.Artifacts.NetworkRequest>;
+  }
 }
 
 declare module 'lighthouse/lighthouse-core/computed/page-dependency-graph.js' {
-  export function getNetworkInitiators(record: LH.Artifacts.NetworkRequest): Array<string>;
+  export default {
+    getNetworkInitiators(record: LH.Artifacts.NetworkRequest): Array<string>;
+  }
 }
 
 declare module 'lighthouse/lighthouse-core/computed/main-thread-tasks.js' {
-  export function request(trace: LH.Trace, context: LH.Audit.Context): Promise<Array<TaskNode>>;
+  export default {
+    request(trace: LH.Trace, context: LH.Audit.Context): Promise<Array<TaskNode>>;
+  }
 }
 
 declare module 'lighthouse/lighthouse-core/lib/i18n/i18n.js'; {

--- a/lighthouse-plugin-publisher-ads/utils/array.js
+++ b/lighthouse-plugin-publisher-ads/utils/array.js
@@ -68,6 +68,6 @@ function flatten(arrs) {
   return result;
 }
 
-module.exports = {
+export {
   count, bucket, flatten,
 };

--- a/lighthouse-plugin-publisher-ads/utils/asserts.js
+++ b/lighthouse-plugin-publisher-ads/utils/asserts.js
@@ -22,6 +22,6 @@ function assert(x) {
   return x;
 }
 
-module.exports = {
+export {
   assert,
 };

--- a/lighthouse-plugin-publisher-ads/utils/bidder-patterns.js
+++ b/lighthouse-plugin-publisher-ads/utils/bidder-patterns.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module.exports = [
+export default [
   {
     label: 'Prebid JS',
     patterns: [

--- a/lighthouse-plugin-publisher-ads/utils/geometry.js
+++ b/lighthouse-plugin-publisher-ads/utils/geometry.js
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/** @typedef {Omit<ClientRect, 'x'|'y'|'toJSON'>} Rect */
+
 /**
- * @param {ClientRect} clientRect
+ * @param {Rect} clientRect
  * @param {LH.Artifacts.ViewportDimensions} viewport
  * @return {boolean}
  */
@@ -26,7 +28,7 @@ function isBoxInViewport(clientRect, viewport) {
 }
 
 /**
- * @param {ClientRect} clientRect
+ * @param {Rect} clientRect
  * @param {LH.Artifacts.ViewportDimensions} viewport
  * @return {number}
  */
@@ -41,9 +43,9 @@ function boxViewableArea(clientRect, viewport) {
 }
 
 /**
- * Converts points (from a TraceEvent) to a ClientRect.
+ * Converts points (from a TraceEvent) to a Rect.
  * @param {number[]} points
- * @return {ClientRect}
+ * @return {Rect}
  */
 function toClientRect([left, top, width, height]) {
   return {
@@ -57,10 +59,10 @@ function toClientRect([left, top, width, height]) {
 }
 
 /**
- * Checks ClientRect a overlaps ClientRect b. Note that this returns true for
+ * Checks Rect a overlaps Rect b. Note that this returns true for
  * overlapping perimeters.
- * @param {ClientRect} a
- * @param {ClientRect} b
+ * @param {Rect} a
+ * @param {Rect} b
  * @return {boolean}
  */
 function overlaps(a, b) {
@@ -69,10 +71,9 @@ function overlaps(a, b) {
   return overlapX && overlapY;
 }
 
-module.exports = {
+export {
   boxViewableArea,
   isBoxInViewport,
   overlaps,
   toClientRect,
 };
-

--- a/lighthouse-plugin-publisher-ads/utils/graph.js
+++ b/lighthouse-plugin-publisher-ads/utils/graph.js
@@ -12,21 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const BaseNode = require('lighthouse/lighthouse-core/lib/dependency-graph/base-node.js');
+import {BaseNode} from 'lighthouse/lighthouse-core/lib/dependency-graph/base-node.js';
+
 // eslint-disable-next-line no-unused-vars
-const CpuNode = require('lighthouse/lighthouse-core/lib/dependency-graph/cpu-node.js');
+import {CPUNode} from 'lighthouse/lighthouse-core/lib/dependency-graph/cpu-node.js';
+
 // eslint-disable-next-line no-unused-vars
-const NetworkNode = require('lighthouse/lighthouse-core/lib/dependency-graph/network-node.js');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
-const {assert} = require('./asserts');
-const {getNameOrTld, trimUrl} = require('../utils/resource-classification');
-const {getNetworkInitiators} = require('lighthouse/lighthouse-core/computed/page-dependency-graph.js');
-const {getTimingsByRecord} = require('../utils/network-timing');
-const {isAdRequest, isAdSense, isGpt, isBidRequest, isAdRelated} = require('./resource-classification');
+import {NetworkNode} from 'lighthouse/lighthouse-core/lib/dependency-graph/network-node.js';
+
+import NetworkRecords from 'lighthouse/lighthouse-core/computed/network-records.js';
+import {assert} from './asserts.js';
+import {getNameOrTld, trimUrl} from '../utils/resource-classification.js';
+import PageDependencyGraph from 'lighthouse/lighthouse-core/computed/page-dependency-graph.js';
+import {getTimingsByRecord} from '../utils/network-timing.js';
+import {isAdRequest, isAdSense, isGpt, isBidRequest, isAdRelated} from './resource-classification.js';
 
 /** @typedef {LH.Gatherer.Simulation.NodeTiming} NodeTiming */
 /** @typedef {LH.TraceEvent} TraceEvent */
 /** @typedef {LH.Artifacts.NetworkRequest} NetworkRequest */
+// eslint-disable-next-line max-len
+/** @typedef {import('lighthouse/lighthouse-core/lib/dependency-graph/base-node.js').Node} Node */
 
 /**
  * @typedef {Object} NetworkSummary
@@ -36,7 +41,7 @@ const {isAdRequest, isAdSense, isGpt, isBidRequest, isAdRelated} = require('./re
  */
 
 /**
- * @param {BaseNode.Node} root The root node of the DAG.
+ * @param {Node} root The root node of the DAG.
  * @param {(req: NetworkRequest) => boolean} isTargetRequest
  * @return {?NetworkNode}
  */
@@ -58,12 +63,12 @@ function findTargetRequest(root, isTargetRequest) {
 /**
  * Returns all requests and CPU tasks in the loading graph of the target
  * requests.
- * @param {BaseNode.Node} root The root node of the DAG.
+ * @param {Node} root The root node of the DAG.
  * @param {(req: NetworkRequest) => boolean} isTargetRequest
  * @return {{requests: NetworkRequest[], traceEvents: TraceEvent[]}}
  */
 function getTransitiveClosure(root, isTargetRequest) {
-  /** @type {Set<BaseNode.Node>} */
+  /** @type {Set<Node>} */
   const closure = new Set();
   /** @type {?NetworkNode} */
   const firstTarget = findTargetRequest(root, isTargetRequest);
@@ -77,7 +82,7 @@ function getTransitiveClosure(root, isTargetRequest) {
     return {requests, traceEvents};
   }
 
-  /** @type {BaseNode.Node[]} */ const stack = [firstTarget];
+  /** @type {Node[]} */ const stack = [firstTarget];
 
   // Search target -> root
   while (stack.length) {
@@ -156,7 +161,7 @@ function addInitiatedRequests(
       .filter((r) => ['Script', 'XHR'].includes(r.resourceType || '') &&
           r.endTime < parentReq.startTime)
       .filter((r) => r.initiatorRequest == scriptReq ||
-        getNetworkInitiators(r).includes(scriptReq.url));
+        PageDependencyGraph.getNetworkInitiators(r).includes(scriptReq.url));
 
   for (const initiatedReq of initiatedRequests) {
     // TODO(warrengm): Check for JSONP and Fetch requests.
@@ -415,7 +420,7 @@ async function computeAdRequestWaterfall(trace, devtoolsLog, context) {
   return result;
 }
 
-module.exports = {
+export {
   getTransitiveClosure,
   getCriticalGraph,
   computeAdRequestWaterfall,

--- a/lighthouse-plugin-publisher-ads/utils/network-timing.js
+++ b/lighthouse-plugin-publisher-ads/utils/network-timing.js
@@ -12,19 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const AdLanternMetric = require('../computed/ad-lantern-metric');
+import AdLanternMetric from '../computed/ad-lantern-metric.js';
+
 // @ts-ignore
-const LoadSimulator = require('lighthouse/lighthouse-core/computed/load-simulator.js');
-const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records.js');
-const PageDependencyGraph = require('lighthouse/lighthouse-core/computed/page-dependency-graph.js');
-const {isAdRequest, isBidRequest, isImplTag, isImpressionPing} = require('./resource-classification');
+import LoadSimulator from 'lighthouse/lighthouse-core/computed/load-simulator.js';
+
+import NetworkRecords from 'lighthouse/lighthouse-core/computed/network-records.js';
+import PageDependencyGraph from 'lighthouse/lighthouse-core/computed/page-dependency-graph.js';
+import {isAdRequest, isBidRequest, isImplTag, isImpressionPing} from './resource-classification.js';
 
 /** @typedef {LH.Artifacts.NetworkRequest} NetworkRequest */
 /** @typedef {LH.Gatherer.Simulation.NodeTiming} NodeTiming */
 
 /* eslint-disable max-len */
-/** @typedef {import('lighthouse/lighthouse-core/lib/dependency-graph/base-node.js').Node} Node */
-/** @typedef {import('lighthouse/lighthouse-core/lib/dependency-graph/network-node.js')} NetworkNode */
+/** @typedef {import('lighthouse/lighthouse-core/lib/dependency-graph/network-node.js').NetworkNode} NetworkNode */
 /* eslint-enable max-len */
 
 /**
@@ -204,7 +205,7 @@ async function getScriptEvaluationTimes(trace, devtoolsLog, context) {
   return simulatedTimes;
 }
 
-module.exports = {
+export {
   getTagEndTime,
   getImpressionStartTime,
   getAdStartTime,

--- a/lighthouse-plugin-publisher-ads/utils/network.js
+++ b/lighthouse-plugin-publisher-ads/utils/network.js
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 // @ts-ignore
-const CacheHeaders = require('lighthouse/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js');
+import CacheHeaders from 'lighthouse/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js';
+
 // @ts-ignore
-const {parse: parseCacheControl} = require('@tusbar/cache-control');
+import {parse as parseCacheControl} from '@tusbar/cache-control';
 
 /**
  * @param {LH.Artifacts.NetworkRequest} req
@@ -53,6 +54,6 @@ function isCacheable(req) {
   return !!getHeader(req, 'expires') || !!getHeader(req, 'last-modified');
 }
 
-module.exports = {
+export {
   isCacheable,
 };

--- a/lighthouse-plugin-publisher-ads/utils/resource-classification.js
+++ b/lighthouse-plugin-publisher-ads/utils/resource-classification.js
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const bidderPatterns = require('./bidder-patterns');
-const thirdPartyWeb = require('lighthouse/lighthouse-core/lib/third-party-web.js');
-const {isCacheable} = require('../utils/network');
+import bidderPatterns from './bidder-patterns.js';
+import thirdPartyWeb from 'lighthouse/lighthouse-core/lib/third-party-web.js';
+import {isCacheable} from '../utils/network.js';
 
 /**
  * Converts the given url to a URL, if it's not already a URL. Otherwise returns
@@ -417,7 +417,7 @@ function isAdRelated(requestOrUrl) {
   return false;
 }
 
-module.exports = {
+export {
   isGoogleAds,
   isGptAdRequest,
   isImpressionPing,

--- a/lighthouse-plugin-publisher-ads/utils/tasks.js
+++ b/lighthouse-plugin-publisher-ads/utils/tasks.js
@@ -40,4 +40,4 @@ function getAttributableUrl(longTask, knownScripts = new Set()) {
   return childUrl;
 }
 
-module.exports = {getAttributableUrl};
+export {getAttributableUrl};

--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -1,3 +1,5 @@
+// LHCI currently does not support .cjs, so generate a json config with:
+//    node -e 'console.log(JSON.stringify(require("./lighthouserc.cjs"), null, 2))' > lighthouserc.json
 module.exports = {
   ci: {
     upload: {

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,135 @@
+{
+  "ci": {
+    "upload": {
+      "target": "temporary-public-storage"
+    },
+    "collect": {
+      "staticDistDir": "./lighthouse-ci/mock-pages",
+      "settings": {
+        "onlyCategories": [
+          "lighthouse-plugin-publisher-ads",
+          "performance"
+        ],
+        "plugins": [
+          "lighthouse-plugin-publisher-ads"
+        ]
+      }
+    },
+    "assert": {
+      "assertMatrix": [
+        {
+          "matchingUrlPattern": ".*/fast-ads.html",
+          "assertions": {
+            "categories:lighthouse-plugin-publisher-ads": [
+              "error",
+              {
+                "minScore": 1
+              }
+            ],
+            "tag-load-time": [
+              "error",
+              {
+                "maxNumericValue": 2850
+              }
+            ],
+            "ad-request-from-page-start": [
+              "error",
+              {
+                "maxNumericValue": 2800
+              }
+            ],
+            "first-ad-render": [
+              "error",
+              {
+                "maxNumericValue": 3300
+              }
+            ],
+            "categories:performance": [
+              "error",
+              {
+                "minScore": 0.85
+              }
+            ],
+            "first-contentful-paint": [
+              "error",
+              {
+                "maxNumericValue": 750
+              }
+            ],
+            "speed-index": [
+              "error",
+              {
+                "maxNumericValue": 2000
+              }
+            ],
+            "largest-contentful-paint": [
+              "error",
+              {
+                "maxNumericValue": 750
+              }
+            ],
+            "interactive": [
+              "error",
+              {
+                "maxNumericValue": 5000
+              }
+            ],
+            "total-blocking-time": [
+              "error",
+              {
+                "maxNumericValue": 750
+              }
+            ],
+            "cumulative-layout-shift": [
+              "error",
+              {
+                "maxNumericValue": 0
+              }
+            ]
+          }
+        },
+        {
+          "matchingUrlPattern": ".*/slow-ads.html",
+          "assertions": {
+            "categories:lighthouse-plugin-publisher-ads": [
+              "error",
+              {
+                "minScore": 0.2
+              }
+            ],
+            "ad-request-from-page-start": [
+              "error",
+              {
+                "maxNumericValue": 24000
+              }
+            ],
+            "first-ad-render": [
+              "error",
+              {
+                "maxNumericValue": 27000
+              }
+            ],
+            "cumulative-layout-shift": [
+              "error",
+              {
+                "maxNumericValue": 3.54
+              }
+            ],
+            "viewport-ad-density": [
+              "error",
+              {
+                "maxNumericValue": 0.33
+              }
+            ],
+            "ad-blocking-tasks": [
+              "error",
+              {
+                "maxLength": 2
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "lighthouse-plugin-publisher-ads-wrapper",
   "version": "1.5.6",
+  "type": "module",
   "description": "Wrapper for Publisher Ads Lighthouse Plugin.",
   "author": "Google Ads",
   "license": "Apache-2.0",
-  "main": "index.js",
+  "main": "index.cjs",
   "scripts": {
-    "lint": "eslint -c lighthouse-plugin-publisher-ads/.eslintrc.js .",
+    "lint": "eslint -c lighthouse-plugin-publisher-ads/.eslintrc.cjs .",
     "debug": "mocha debug lighthouse-plugin-publisher-ads/test/{audits,utils}/*.js",
     "test": "mocha lighthouse-plugin-publisher-ads/test/{audits,utils}/*.js",
     "smoke": "node lighthouse-plugin-publisher-ads/test/smoke/run-smoke.js",
@@ -21,13 +22,15 @@
   "dependencies": {
     "@tusbar/cache-control": "^0.3.1",
     "@types/esprima": "^4.0.2",
-    "lighthouse": "^8.6.0",
+    "lighthouse": "9.5.0-dev.20220728",
     "lodash.clonedeep": "^4.5.0",
     "yargs": "16.1.1"
   },
   "devDependencies": {
     "@lhci/cli": "0.7.x",
+    "@types/lodash": "^4.14.178",
     "@types/yargs": "^15.0.11",
+    "@typescript-eslint/parser": "^5.31.0",
     "chai": "^4.1.2",
     "eslint": "^6.0.1",
     "eslint-config-google": "^0.12.0",
@@ -36,6 +39,6 @@
     "mocha": "^8.3.2",
     "sinon": "^5.0.7",
     "static-server": "^2.2.1",
-    "typescript": "^4.1.2"
+    "typescript": "^4.7.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,23 +3,23 @@
 
 
 "@babel/code-frame@^7.0.0":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
-  integrity sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
+  integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
   dependencies:
-    "@babel/highlight" "^7.12.13"
+    "@babel/highlight" "^7.18.6"
 
-"@babel/helper-validator-identifier@^7.12.11":
-  version "7.12.11"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
-  integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
+"@babel/helper-validator-identifier@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
+  integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
 
-"@babel/highlight@^7.12.13":
-  version "7.13.10"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.13.10.tgz#a8b2a66148f5b27d666b15d81774347a731d52d1"
-  integrity sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==
+"@babel/highlight@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.18.6.tgz#81158601e93e2563795adcbfbdf5d64be3f2ecdf"
+  integrity sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.12.11"
+    "@babel/helper-validator-identifier" "^7.18.6"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
@@ -54,6 +54,83 @@
     js-yaml "^3.13.1"
     lighthouse "7.3.0"
     tree-kill "^1.2.1"
+
+"@nodelib/fs.scandir@2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
+  integrity sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.5"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
+  integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
+  integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.5"
+    fastq "^1.6.0"
+
+"@sentry/core@6.19.7":
+  version "6.19.7"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.19.7.tgz#156aaa56dd7fad8c89c145be6ad7a4f7209f9785"
+  integrity sha512-tOfZ/umqB2AcHPGbIrsFLcvApdTm9ggpi/kQZFkej7kMphjT+SGBiQfYtjyg9jcRW+ilAR4JXC9BGKsdEQ+8Vw==
+  dependencies:
+    "@sentry/hub" "6.19.7"
+    "@sentry/minimal" "6.19.7"
+    "@sentry/types" "6.19.7"
+    "@sentry/utils" "6.19.7"
+    tslib "^1.9.3"
+
+"@sentry/hub@6.19.7":
+  version "6.19.7"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.19.7.tgz#58ad7776bbd31e9596a8ec46365b45cd8b9cfd11"
+  integrity sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==
+  dependencies:
+    "@sentry/types" "6.19.7"
+    "@sentry/utils" "6.19.7"
+    tslib "^1.9.3"
+
+"@sentry/minimal@6.19.7":
+  version "6.19.7"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.19.7.tgz#b3ee46d6abef9ef3dd4837ebcb6bdfd01b9aa7b4"
+  integrity sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==
+  dependencies:
+    "@sentry/hub" "6.19.7"
+    "@sentry/types" "6.19.7"
+    tslib "^1.9.3"
+
+"@sentry/node@^6.17.4":
+  version "6.19.7"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.19.7.tgz#32963b36b48daebbd559e6f13b1deb2415448592"
+  integrity sha512-gtmRC4dAXKODMpHXKfrkfvyBL3cI8y64vEi3fDD046uqYcrWdgoQsffuBbxMAizc6Ez1ia+f0Flue6p15Qaltg==
+  dependencies:
+    "@sentry/core" "6.19.7"
+    "@sentry/hub" "6.19.7"
+    "@sentry/types" "6.19.7"
+    "@sentry/utils" "6.19.7"
+    cookie "^0.4.1"
+    https-proxy-agent "^5.0.0"
+    lru_map "^0.3.3"
+    tslib "^1.9.3"
+
+"@sentry/types@6.19.7":
+  version "6.19.7"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.19.7.tgz#c6b337912e588083fc2896eb012526cf7cfec7c7"
+  integrity sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==
+
+"@sentry/utils@6.19.7":
+  version "6.19.7"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.19.7.tgz#6edd739f8185fd71afe49cbe351c1bbf5e7b7c79"
+  integrity sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==
+  dependencies:
+    "@sentry/types" "6.19.7"
+    tslib "^1.9.3"
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -120,6 +197,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
+"@types/lodash@^4.14.178":
+  version "4.14.182"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
+  integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
+
 "@types/node@*":
   version "14.14.37"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.37.tgz#a3dd8da4eb84a996c36e331df98d82abd76b516e"
@@ -142,6 +224,57 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/yauzl@^2.9.1":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.10.0.tgz#b3248295276cf8c6f153ebe6a9aba0c988cb2599"
+  integrity sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==
+  dependencies:
+    "@types/node" "*"
+
+"@typescript-eslint/parser@^5.31.0":
+  version "5.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.31.0.tgz#7f42d7dcc68a0a6d80a0f3d9a65063aee7bb8d2c"
+  integrity sha512-UStjQiZ9OFTFReTrN+iGrC6O/ko9LVDhreEK5S3edmXgR396JGq7CoX2TWIptqt/ESzU2iRKXAHfSF2WJFcWHw==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.31.0"
+    "@typescript-eslint/types" "5.31.0"
+    "@typescript-eslint/typescript-estree" "5.31.0"
+    debug "^4.3.4"
+
+"@typescript-eslint/scope-manager@5.31.0":
+  version "5.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.31.0.tgz#f47a794ba84d9b818ab7f8f44fff55a61016c606"
+  integrity sha512-8jfEzBYDBG88rcXFxajdVavGxb5/XKXyvWgvD8Qix3EEJLCFIdVloJw+r9ww0wbyNLOTYyBsR+4ALNGdlalLLg==
+  dependencies:
+    "@typescript-eslint/types" "5.31.0"
+    "@typescript-eslint/visitor-keys" "5.31.0"
+
+"@typescript-eslint/types@5.31.0":
+  version "5.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.31.0.tgz#7aa389122b64b18e473c1672fb3b8310e5f07a9a"
+  integrity sha512-/f/rMaEseux+I4wmR6mfpM2wvtNZb1p9hAV77hWfuKc3pmaANp5dLAZSiE3/8oXTYTt3uV9KW5yZKJsMievp6g==
+
+"@typescript-eslint/typescript-estree@5.31.0":
+  version "5.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.31.0.tgz#eb92970c9d6e3946690d50c346fb9b1d745ee882"
+  integrity sha512-3S625TMcARX71wBc2qubHaoUwMEn+l9TCsaIzYI/ET31Xm2c9YQ+zhGgpydjorwQO9pLfR/6peTzS/0G3J/hDw==
+  dependencies:
+    "@typescript-eslint/types" "5.31.0"
+    "@typescript-eslint/visitor-keys" "5.31.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/visitor-keys@5.31.0":
+  version "5.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.31.0.tgz#b0eca264df01ce85dceb76aebff3784629258f54"
+  integrity sha512-ZK0jVxSjS4gnPirpVjXHz7mgdOsZUHzNYSfTw2yPa3agfbt9YfqaBiBZFSSxeBWnpWkzCxTfUpnzA3Vily/CSg==
+  dependencies:
+    "@typescript-eslint/types" "5.31.0"
+    eslint-visitor-keys "^3.3.0"
+
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
@@ -161,14 +294,21 @@ accepts@~1.3.5, accepts@~1.3.7:
     negotiator "0.6.2"
 
 acorn-jsx@^5.2.0:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
-  integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
+  integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
 acorn@^7.1.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
 
 ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3:
   version "6.12.6"
@@ -224,6 +364,11 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
 ansi-styles@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.1.0.tgz#eaecbf66cd706882760b2f4691582b8f55d7a7de"
@@ -273,6 +418,11 @@ array-from@^2.1.1:
   resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
   integrity sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
 
+array-union@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
+  integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
 asn1@~0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
@@ -320,15 +470,20 @@ axe-core@4.1.3:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.3.tgz#64a4c85509e0991f5168340edc4bedd1ceea6966"
   integrity sha512-vwPpH4Aj4122EW38mxO/fxhGKtwWTMLDIJfZ1He0Edbtjcfna/R3YB67yVhezUMzqc3Jr3+Ii50KRntlENL4xQ==
 
-axe-core@4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.2.3.tgz#2a3afc332f0031b42f602f4a3de03c211ca98f72"
-  integrity sha512-pXnVMfJKSIWU2Ml4JHP7pZEPIrgBO1Fd3WGx+fPBsS+KRGhE4vxooD8XBGWbQOIVSZsVK7pUDBBkCicNu80yzQ==
+axe-core@4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
+  integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
 
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
@@ -341,6 +496,15 @@ binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+bl@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
 
 body-parser@1.19.0:
   version "1.19.0"
@@ -394,7 +558,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@~3.0.2:
+braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -405,6 +569,19 @@ browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
+
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
+
+buffer@^5.2.1, buffer@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -521,7 +698,15 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
@@ -559,6 +744,11 @@ chokidar@3.5.1:
   optionalDependencies:
     fsevents "~2.3.1"
 
+chownr@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
+
 chrome-launcher@^0.13.4:
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.13.4.tgz#4c7d81333c98282899c4e38256da23e00ed32f73"
@@ -571,10 +761,10 @@ chrome-launcher@^0.13.4:
     mkdirp "^0.5.3"
     rimraf "^3.0.2"
 
-chrome-launcher@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.14.0.tgz#de8d8a534ccaeea0f36ea8dc12dd99e3169f3320"
-  integrity sha512-W//HpflaW6qBGrmuskup7g+XJZN6w03ko9QSIe5CtcTal2u0up5SeReK3Ll1Why4Ey8dPkv8XSodZyHPnGbVHQ==
+chrome-launcher@^0.15.1:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.15.1.tgz#0a0208037063641e2b3613b7e42b0fcb3fa2d399"
+  integrity sha512-UugC8u59/w2AyX5sHLZUHoxBAiSiunUhZa3zZwMH6zPVis0C3dDKiRWyUGIo14tTbZHGVviWxv3PQWZ7taZ4fg==
   dependencies:
     "@types/node" "*"
     escape-string-regexp "^4.0.0"
@@ -752,6 +942,11 @@ cookie@0.4.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
+cookie@^0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
 core-util-is@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -766,6 +961,13 @@ cosmiconfig@^5.2.0:
     is-directory "^0.3.1"
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
+
+cross-fetch@3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -838,7 +1040,14 @@ debug@2.6.9, debug@^2.6.8, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4.3.1, debug@^4.0.1, debug@^4.3.1:
+debug@4, debug@4.3.4, debug@^4.0.1, debug@^4.1.1, debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
+debug@4.3.1, debug@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -875,14 +1084,19 @@ deep-extend@^0.6.0:
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
-  integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
+  integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
 defer-to-connect@^1.0.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz#331ae050c08dcf789f8c83a7b81f0ed94f4ac591"
   integrity sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==
+
+define-lazy-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
 
 define-properties@^1.1.3:
   version "1.1.3"
@@ -911,6 +1125,11 @@ details-element-polyfill@^2.4.0:
   resolved "https://registry.yarnpkg.com/details-element-polyfill/-/details-element-polyfill-2.4.0.tgz#e0622adef7902662faf27b4ab8acba5dc4e3a6e6"
   integrity sha512-jnZ/m0+b1gz3EcooitqL7oDEkKHEro659dt8bWB/T/HjiILucoQhHvvi5MEOAIFJXxxO+rIYJ/t3qCgfUOSU5g==
 
+devtools-protocol@0.0.981744:
+  version "0.0.981744"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.981744.tgz#9960da0370284577d46c28979a0b32651022bacf"
+  integrity sha512-0cuGS8+jhR67Fy7qG3i3Pc7Aw494sb9yG9QgpG97SFVWwolgYjlhJg7n+UaHxOQT30d1TYu/EYe9k01ivLErIg==
+
 diff@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
@@ -920,6 +1139,13 @@ diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
+dir-glob@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
+  integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
+  dependencies:
+    path-type "^4.0.0"
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -975,7 +1201,7 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-end-of-stream@^1.1.0:
+end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
@@ -1081,6 +1307,11 @@ eslint-visitor-keys@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
+
+eslint-visitor-keys@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
+  integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
 eslint@^6.0.1:
   version "6.8.0"
@@ -1249,6 +1480,17 @@ external-editor@^3.0.3:
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
+extract-zip@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
+  integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
+  dependencies:
+    debug "^4.1.1"
+    get-stream "^5.1.0"
+    yauzl "^2.10.0"
+  optionalDependencies:
+    "@types/yauzl" "^2.9.1"
+
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -1264,6 +1506,17 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
+fast-glob@^3.2.9:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
+  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -1272,7 +1525,21 @@ fast-json-stable-stringify@^2.0.0:
 fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
-  integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+  integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
+
+fastq@^1.6.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"
+  integrity sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==
+  dependencies:
+    reusify "^1.0.4"
+
+fd-slicer@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
+  dependencies:
+    pend "~1.2.0"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -1393,6 +1660,11 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1463,7 +1735,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob-parent@^5.0.0, glob-parent@~5.1.0:
+glob-parent@^5.0.0, glob-parent@^5.1.2, glob-parent@~5.1.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -1502,6 +1774,18 @@ globals@^12.1.0:
   integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
   dependencies:
     type-fest "^0.8.1"
+
+globby@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
+  integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.9"
+    ignore "^5.2.0"
+    merge2 "^1.4.1"
+    slash "^3.0.0"
 
 got@^9.6.0:
   version "9.6.0"
@@ -1633,6 +1917,14 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+https-proxy-agent@5.0.1, https-proxy-agent@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 husky@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/husky/-/husky-2.4.0.tgz#1bac7c44588f6e91f808b72efc82d24a57194f36"
@@ -1656,10 +1948,20 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+ieee754@^1.1.13:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
 ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
+  integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
 image-ssim@^0.2.0:
   version "0.2.0"
@@ -1700,7 +2002,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4:
+inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -1836,7 +2138,7 @@ is-directory@^0.3.1:
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
-is-docker@^2.0.0:
+is-docker@^2.0.0, is-docker@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
   integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
@@ -1860,6 +2162,13 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
+
+is-glob@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
 
@@ -2006,10 +2315,20 @@ jpeg-js@^0.4.1:
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.3.tgz#6158e09f1983ad773813704be80680550eff977b"
   integrity sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==
 
+jpeg-js@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.4.tgz#a9f1c6f1f9f0fa80cdb3484ed9635054d28936aa"
+  integrity sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==
+
 js-library-detector@^6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/js-library-detector/-/js-library-detector-6.4.0.tgz#63e165cb84a4a0a7f7bbf1e97d60623921baae14"
   integrity sha512-NB2sYpmgqiTd7PNNhgp6bnEZmjvTUdAbzxABvYXWLpTL/t158T6mPnD8uYNd0FDP73YWyMrTYDvPxqdvCTbv2g==
+
+js-library-detector@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/js-library-detector/-/js-library-detector-6.5.0.tgz#96de02e9926a185c2d7a9a6967286d2ba20b5f79"
+  integrity sha512-Kq7VckJ5kb26kHMAu1sDO8t2qr7M5Uw6Gf7fVGtu1YceoHdqTcobwnB5kStcktusPuPmiCE8PbCaiLzhiBsSAw==
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -2119,7 +2438,7 @@ latest-version@^5.0.0:
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
-  integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
+  integrity sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
@@ -2140,15 +2459,15 @@ lighthouse-logger@^1.3.0:
     debug "^2.6.9"
     marky "^1.2.2"
 
+lighthouse-stack-packs@1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/lighthouse-stack-packs/-/lighthouse-stack-packs-1.8.2.tgz#55111bebe50ed516de3fad0a474795a2556ac36e"
+  integrity sha512-vlCUxxQAB8Nu6LQHqPpDRiMi06Du593/my/6JbMttQeEfJ7pf4OS8obSTh5xSOS80U/O7fq59Q8rQGAUxQatUQ==
+
 lighthouse-stack-packs@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/lighthouse-stack-packs/-/lighthouse-stack-packs-1.4.0.tgz#bf98e0fb04a091ec2d73648842698b41070968ef"
   integrity sha512-wdv94WUjaqUwtW8DOapng45Yah62c5O5geNVeoSQlnoagfbTO/YbiwNlfzDIF1xNKRkPlsfr/oWHhXsaHXDivg==
-
-lighthouse-stack-packs@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/lighthouse-stack-packs/-/lighthouse-stack-packs-1.5.0.tgz#c191f2b94db21602254baaebfb0bb90307a00ffa"
-  integrity sha512-ntVOqFsrrTQYrNf+W+sNE9GjddW+ab5QN0WrrCikjMFsUvEQ28CvT0SXcHPZXFtcsb1lMSuVaNCmEuj7oXtYGQ==
 
 lighthouse@7.3.0:
   version "7.3.0"
@@ -2191,41 +2510,38 @@ lighthouse@7.3.0:
     yargs "^16.1.1"
     yargs-parser "^20.2.4"
 
-lighthouse@^8.6.0:
-  version "8.6.0"
-  resolved "https://registry.yarnpkg.com/lighthouse/-/lighthouse-8.6.0.tgz#e50ca532aca2ca7fec409caea6bddd940450041a"
-  integrity sha512-/H7aDL3//Gr0M1v8GGq6k0OTNty7nDVuU/o1cg6opYkfHRz1V3Nhydqz6aBzfXhUQx6iJRnxgRCPya+ZLA2vbg==
+lighthouse@9.5.0-dev.20220728:
+  version "9.5.0-dev.20220728"
+  resolved "https://registry.yarnpkg.com/lighthouse/-/lighthouse-9.5.0-dev.20220728.tgz#c804147020ab9b067f5ae4959617d5d5b2e35777"
+  integrity sha512-3n+fF/8CJ1D1VGaIsQqPGCFQb+RZQmphMOoD8lDtGXDk95hvr0HWcCCpLlxKqxr7uCASrySM1w5ZvfNw7FeT1g==
   dependencies:
-    axe-core "4.2.3"
-    chrome-launcher "^0.14.0"
+    "@sentry/node" "^6.17.4"
+    axe-core "4.4.1"
+    chrome-launcher "^0.15.1"
     configstore "^5.0.1"
     csp_evaluator "1.1.0"
     cssstyle "1.2.1"
     enquirer "^2.3.6"
     http-link-header "^0.8.0"
     intl-messageformat "^4.4.0"
-    jpeg-js "^0.4.1"
-    js-library-detector "^6.4.0"
+    jpeg-js "^0.4.4"
+    js-library-detector "^6.5.0"
     lighthouse-logger "^1.3.0"
-    lighthouse-stack-packs "^1.5.0"
-    lodash.clonedeep "^4.5.0"
-    lodash.get "^4.4.2"
-    lodash.isequal "^4.5.0"
-    lodash.set "^4.3.2"
-    lookup-closest-locale "6.0.4"
+    lighthouse-stack-packs "1.8.2"
+    lodash "^4.17.21"
+    lookup-closest-locale "6.2.0"
     metaviewport-parser "0.2.0"
-    open "^6.4.0"
+    open "^8.4.0"
     parse-cache-control "1.0.1"
-    ps-list "^7.2.0"
-    raven "^2.2.1"
-    robots-parser "^2.0.1"
+    ps-list "^8.0.0"
+    puppeteer-core "^13.7.0"
+    robots-parser "^3.0.0"
     semver "^5.3.0"
     speedline-core "^1.4.3"
-    third-party-web "^0.12.4"
-    update-notifier "^4.1.0"
+    third-party-web "^0.17.1"
     ws "^7.0.0"
-    yargs "^16.1.1"
-    yargs-parser "^20.2.4"
+    yargs "^17.3.1"
+    yargs-parser "^21.0.0"
 
 locate-path@^3.0.0:
   version "3.0.0"
@@ -2269,7 +2585,7 @@ lodash.set@^4.3.2:
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
   integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.19:
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -2296,6 +2612,11 @@ lookup-closest-locale@6.0.4:
   resolved "https://registry.yarnpkg.com/lookup-closest-locale/-/lookup-closest-locale-6.0.4.tgz#1279fed7546a601647bbc980f64423ee990a8590"
   integrity sha512-bWoFbSGe6f1GvMGzj17LrwMX4FhDXDwZyH04ySVCPbtOJADcSRguZNKewoJ3Ful/MOxD/wRHvFPadk/kYZUbuQ==
 
+lookup-closest-locale@6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/lookup-closest-locale/-/lookup-closest-locale-6.2.0.tgz#57f665e604fd26f77142d48152015402b607bcf3"
+  integrity sha512-/c2kL+Vnp1jnV6K6RpDTHK3dgg0Tu2VVp+elEiJpjfS1UyY7AjOYHohRug6wT0OpoX2qFgNORndE9RqesfVxWQ==
+
 lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
@@ -2320,6 +2641,18 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
+lru_map@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
+  integrity sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==
 
 make-dir@^1.0.0:
   version "1.3.0"
@@ -2364,6 +2697,11 @@ merge-descriptors@1.0.1:
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
 
+merge2@^1.3.0, merge2@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
 metaviewport-parser@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/metaviewport-parser/-/metaviewport-parser-0.2.0.tgz#535c3ce1ccf6223a5025fddc6a1c36505f7e7db1"
@@ -2373,6 +2711,14 @@ methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
+
+micromatch@^4.0.4:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
+  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
+  dependencies:
+    braces "^3.0.2"
+    picomatch "^2.3.1"
 
 mime-db@1.47.0, "mime-db@>= 1.43.0 < 2":
   version "1.47.0"
@@ -2413,12 +2759,24 @@ minimatch@3.0.4, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
-mkdirp@^0.5.1, mkdirp@^0.5.3:
+mkdirp-classic@^0.5.2:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
+
+mkdirp@^0.5.1:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
+  dependencies:
+    minimist "^1.2.6"
+
+mkdirp@^0.5.3:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -2426,9 +2784,9 @@ mkdirp@^0.5.1, mkdirp@^0.5.3:
     minimist "^1.2.5"
 
 mocha@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-8.3.2.tgz#53406f195fa86fbdebe71f8b1c6fb23221d69fcc"
-  integrity sha512-UdmISwr/5w+uXLPKspgoV7/RXZwKRTiTjJ2/AC5ZiEztIoOYdfKb19+9jNmEInzx5pBsCyJQzarAxqIGBNYJhg==
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-8.4.0.tgz#677be88bf15980a3cae03a73e10a0fc3997f0cff"
+  integrity sha512-hJaO0mwDXmZS4ghXsvPVriOhsxQ7ofcpQdm8dE+jISUOKopitvnXFQmpRR7jd2K6VBG6E26gU3IAbXXGIbu4sQ==
   dependencies:
     "@ungap/promise-all-settled" "1.1.2"
     ansi-colors "4.1.1"
@@ -2517,7 +2875,7 @@ nise@^1.3.3:
     lolex "^4.1.0"
     path-to-regexp "^1.7.0"
 
-node-fetch@^2.6.1:
+node-fetch@2.6.7, node-fetch@^2.6.1:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
@@ -2633,6 +2991,15 @@ open@^7.1.0:
   dependencies:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
+
+open@^8.4.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-8.4.0.tgz#345321ae18f8138f82565a910fdc6b39e8c244f8"
+  integrity sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
 
 opn@^5.2.0:
   version "5.5.0"
@@ -2792,10 +3159,20 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
+path-type@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
+  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
 pathval@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
+
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -2807,12 +3184,17 @@ picomatch@^2.0.4, picomatch@^2.2.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.3.tgz#465547f359ccc206d3c48e46a1bcb89bf7ee619d"
   integrity sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==
 
+picomatch@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
 pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
-pkg-dir@^4.1.0:
+pkg-dir@4.2.0, pkg-dir@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
@@ -2829,14 +3211,14 @@ please-upgrade-node@^3.1.1:
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
-  integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
+  integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
 prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-progress@^2.0.0:
+progress@2.0.3, progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -2849,10 +3231,20 @@ proxy-addr@~2.0.5:
     forwarded "~0.1.2"
     ipaddr.js "1.9.1"
 
+proxy-from-env@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 ps-list@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/ps-list/-/ps-list-7.2.0.tgz#3d110e1de8249a4b178c9b1cf2a215d1e4e42fc0"
   integrity sha512-v4Bl6I3f2kJfr5o80ShABNHAokIgY+wFDTQfE+X3zWYgSGQOCBeYptLZUpoOALBqO5EawmDN/tjTldJesd0ujQ==
+
+ps-list@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/ps-list/-/ps-list-8.1.0.tgz#aded36339500cd929f1425ece9bf58ac6d3a213e"
+  integrity sha512-NoGBqJe7Ou3kfQxEvDzDyKGAyEgwIuD3YrfXinjcCmBRv0hTld0Xb71hrXvtsNPj7HSFATfemvzB8PPJtq6Yag==
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -2884,6 +3276,24 @@ pupa@^2.0.1:
   dependencies:
     escape-goat "^2.0.0"
 
+puppeteer-core@^13.7.0:
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-13.7.0.tgz#3344bee3994163f49120a55ddcd144a40575ba5b"
+  integrity sha512-rXja4vcnAzFAP1OVLq/5dWNfwBGuzcOARJ6qGV7oAZhnLmVRU8G5MsdeQEAOy332ZhkIOnn9jp15R89LKHyp2Q==
+  dependencies:
+    cross-fetch "3.1.5"
+    debug "4.3.4"
+    devtools-protocol "0.0.981744"
+    extract-zip "2.0.1"
+    https-proxy-agent "5.0.1"
+    pkg-dir "4.2.0"
+    progress "2.0.3"
+    proxy-from-env "1.1.0"
+    rimraf "3.0.2"
+    tar-fs "2.1.1"
+    unbzip2-stream "1.4.3"
+    ws "8.5.0"
+
 qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
@@ -2893,6 +3303,11 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+queue-microtask@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
+  integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
 randombytes@^2.1.0:
   version "2.1.0"
@@ -2954,6 +3369,15 @@ read-pkg@^5.1.1:
     normalize-package-data "^2.5.0"
     parse-json "^4.0.0"
     type-fest "^0.4.1"
+
+readable-stream@^3.1.1, readable-stream@^3.4.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 readdirp@~3.5.0:
   version "3.5.0"
@@ -3057,10 +3481,22 @@ restore-cursor@^3.1.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
 
+reusify@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
 rimraf@2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
+
+rimraf@3.0.2, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -3071,17 +3507,15 @@ rimraf@^2.6.1, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
-  dependencies:
-    glob "^7.1.3"
-
 robots-parser@^2.0.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/robots-parser/-/robots-parser-2.3.0.tgz#d79e86e26e13fa0a806adbc37f4cf1b96aebc8c3"
   integrity sha512-RvuCITckrHM9k8DxCCU9rqWpuuKRfVX9iHG751dC3/EdERxp9gJATxYYdYOT3L0T+TAT4+27lENisk/VbHm47A==
+
+robots-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/robots-parser/-/robots-parser-3.0.0.tgz#66af89306302ecd004455f2f24298310d0966631"
+  integrity sha512-6xkze3WRdneibICBAzMKcXyTKQw5shA3GbwoEJy7RSvxpZNGF0GMuYKE1T0VMP4fwx/fQs0n0mtriOqRtk5L1w==
 
 run-async@^2.2.0, run-async@^2.4.0:
   version "2.4.1"
@@ -3092,6 +3526,13 @@ run-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
   integrity sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==
+
+run-parallel@^1.1.9:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
+  integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
+  dependencies:
+    queue-microtask "^1.2.2"
 
 rxjs@^6.4.0, rxjs@^6.6.0:
   version "6.6.7"
@@ -3105,7 +3546,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -3153,6 +3594,13 @@ semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
+  dependencies:
+    lru-cache "^6.0.0"
 
 send@0.17.1:
   version "0.17.1"
@@ -3351,6 +3799,15 @@ string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
+string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string.prototype.trimend@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"
@@ -3366,6 +3823,13 @@ string.prototype.trimstart@^1.0.4:
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
+
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
 
 strip-ansi@^0.3.0:
   version "0.3.0"
@@ -3394,6 +3858,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-eof@^1.0.0:
   version "1.0.0"
@@ -3446,6 +3917,27 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
+tar-fs@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
+  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.1.4"
+
+tar-stream@^2.1.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+  dependencies:
+    bl "^4.0.3"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+
 term-size@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
@@ -3468,15 +3960,15 @@ third-party-web@^0.12.2:
   resolved "https://registry.yarnpkg.com/third-party-web/-/third-party-web-0.12.3.tgz#715694cf882d99dfcde228f536464e205ef5c063"
   integrity sha512-wnPlVUKzet4hnejKMEsVj5eIL0V2PLzgjJ3fLyGo9GV1pUOMa0NjeIzJNJ0pTEUL2GJAqlFKxo8EYML27SF/ng==
 
-third-party-web@^0.12.4:
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/third-party-web/-/third-party-web-0.12.5.tgz#df336053ddcbce68aa2da3787641233739ad5a64"
-  integrity sha512-A8YS1bpOzm9os0w7wH/BbN5WZgzyf0zbrrWHckX57v+EkCaM7jZPoRpzgqrakh2e7IWP1KwAnMtlcGTATYZw8A==
+third-party-web@^0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/third-party-web/-/third-party-web-0.17.1.tgz#22e03f1ff519a6380bae4594b704b9bb28e15158"
+  integrity sha512-X9Mha8cVeBwakunlZXkXL6xRzw8VCcDGWqT59EzeTYAJIi8ien3CuufnEGEx4ZUFahumNQdoOwf4H2T9Ca6lBg==
 
-through@^2.3.6:
+through@^2.3.6, through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
-  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+  integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
 timed-out@4.0.1:
   version "4.0.1"
@@ -3532,10 +4024,17 @@ tree-kill@^1.2.1:
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
-tslib@^1.9.0:
+tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tsutils@^3.21.0:
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
+  integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
+  dependencies:
+    tslib "^1.8.1"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -3552,7 +4051,7 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
-  integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
+  integrity sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==
   dependencies:
     prelude-ls "~1.1.2"
 
@@ -3596,10 +4095,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.1.2:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+typescript@^4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 ultron@~1.1.0:
   version "1.1.1"
@@ -3615,6 +4114,14 @@ unbox-primitive@^1.0.0:
     has-bigints "^1.0.1"
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
+
+unbzip2-stream@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
+  integrity sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==
+  dependencies:
+    buffer "^5.2.1"
+    through "^2.3.8"
 
 underscore@^1.9.1:
   version "1.13.0"
@@ -3690,6 +4197,11 @@ url-parse-lax@^3.0.0:
   integrity sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=
   dependencies:
     prepend-http "^2.0.0"
+
+util-deprecate@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 utils-merge@1.0.1:
   version "1.0.1"
@@ -3875,6 +4387,11 @@ ws@3.3.2:
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
 
+ws@8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.5.0.tgz#bfb4be96600757fe5382de12c670dab984a1ed4f"
+  integrity sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==
+
 ws@^7.0.0:
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.5.tgz#8b4bc4af518cfabd0473ae4f99144287b33eb881"
@@ -3910,6 +4427,11 @@ yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
 yargs-parser@20.2.4:
   version "20.2.4"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
@@ -3935,6 +4457,11 @@ yargs-parser@^20.2.2, yargs-parser@^20.2.4:
   version "20.2.7"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.7.tgz#61df85c113edfb5a7a4e36eb8aa60ef423cbc90a"
   integrity sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
+
+yargs-parser@^21.0.0:
+  version "21.0.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
+  integrity sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==
 
 yargs-unparser@2.0.0:
   version "2.0.0"
@@ -3988,6 +4515,27 @@ yargs@^15.4.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yargs@^17.3.1:
+  version "17.5.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.5.1.tgz#e109900cab6fcb7fd44b1d8249166feb0b36e58e"
+  integrity sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.0.0"
+
+yauzl@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  integrity sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.1.0"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Lighthouse 10.0 will be ES modules (#12689) which will require plugins to be ES modules too. Here's a PR that updates everything in this repo to ES modules.

