### PR TITLE
update some 'master' references to 'main'

### DIFF
--- a/config.js
+++ b/config.js
@@ -15,9 +15,9 @@
 /**
  * Config for running lighthouse audits.
  * For the possible types, see
- * https://github.com/GoogleChrome/lighthouse/blob/master/typings/config.d.ts.
+ * https://github.com/GoogleChrome/lighthouse/blob/main/types/config.d.ts
  * and
- * https://github.com/GoogleChrome/lighthouse/tree/master/core/config
+ * https://github.com/GoogleChrome/lighthouse/tree/main/core/config
  * @const {LH.Config}
  */
 const config = {

--- a/lighthouse-ci/README.md
+++ b/lighthouse-ci/README.md
@@ -112,8 +112,8 @@ module.exports = {
 ## Example
 
 There is an
-[example LHCI configuration](https://github.com/googleads/publisher-ads-lighthouse-plugin/blob/master/lighthouserc.js)
+[example LHCI configuration](https://github.com/googleads/publisher-ads-lighthouse-plugin/blob/main/lighthouserc.cjs)
 in this repository that checks 2 mock pages. It utilizes GitHub Actions and the 
  Lighthouse CI GitHub app to demonstrate a simple setup. However, the same 
  assertions can be integrated with 
- [many other popular CI providers](https://github.com/GoogleChrome/lighthouse-ci/blob/master/docs/getting-started.md#configure-your-ci-provider).
+ [many other popular CI providers](https://github.com/GoogleChrome/lighthouse-ci/blob/main/docs/getting-started.md#configure-your-ci-provider).

--- a/lighthouse-plugin-publisher-ads/messages/collect-strings.js
+++ b/lighthouse-plugin-publisher-ads/messages/collect-strings.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Forked from Lighthouse:
-//   https://github.com/GoogleChrome/lighthouse/blob/master/core/scripts/i18n/collect-strings.js
+//   https://github.com/GoogleChrome/lighthouse/blob/main/core/scripts/i18n/collect-strings.js
 'use strict';
 
 /* eslint-disable no-console, max-len */

--- a/lighthouse-plugin-publisher-ads/test/smoke/config.js
+++ b/lighthouse-plugin-publisher-ads/test/smoke/config.js
@@ -15,9 +15,9 @@
 /**
  * Config for running lighthouse audits.
  * For the possible types, see
- * https://github.com/GoogleChrome/lighthouse/blob/master/typings/config.d.ts.
+ * https://github.com/GoogleChrome/lighthouse/blob/main/types/config.d.ts
  * and
- * https://github.com/GoogleChrome/lighthouse/tree/master/core/config
+ * https://github.com/GoogleChrome/lighthouse/tree/main/core/config
  * @const {LH.Config}
  */
 // TODO(jburger): Make Chrome run in headless mode.


### PR DESCRIPTION
we just (finally) changed from `master` to `main` in the lh repo.  https://github.com/GoogleChrome/lighthouse/pull/14409

none of the below changes are too important as there's redirects automatically working for almost all of them.. but... why not. :)